### PR TITLE
(Fix) Inject web3 even if already exists

### DIFF
--- a/app/scripts/contentscript.js
+++ b/app/scripts/contentscript.js
@@ -47,8 +47,8 @@ function setupInjection () {
 function setupStreams () {
   // setup communication to page and plugin
   const pageStream = new LocalMessageDuplexStream({
-    name: 'contentscript',
-    target: 'inpage',
+    name: 'nifty-contentscript',
+    target: 'nifty-inpage',
   })
   const pluginPort = extension.runtime.connect({ name: 'contentscript' })
   const pluginStream = new PortStream(pluginPort)

--- a/app/scripts/inpage.js
+++ b/app/scripts/inpage.js
@@ -15,8 +15,8 @@ log.setDefaultLevel(process.env.METAMASK_DEBUG ? 'debug' : 'warn')
 
 // setup background connection
 var metamaskStream = new LocalMessageDuplexStream({
-  name: 'inpage',
-  target: 'contentscript',
+  name: 'nifty-inpage',
+  target: 'nifty-contentscript',
 })
 
 // compose the inpage provider
@@ -26,13 +26,6 @@ var inpageProvider = new MetamaskInpageProvider(metamaskStream)
 // setup web3
 //
 
-if (typeof window.web3 !== 'undefined') {
-  throw new Error(`MetaMask detected another web3.
-     MetaMask will not work reliably with another web3 extension.
-     This usually happens if you have two MetaMasks installed,
-     or MetaMask and another web3 extension. Please remove one
-     and try again.`)
-}
 var web3 = new Web3(inpageProvider)
 web3.setProvider = function () {
   log.debug('MetaMask - overrode web3.setProvider')


### PR DESCRIPTION
Closes #1 

Injects `web3` even if MetaMask already injected it so the DApps will always use our injected `web3`.
I had to also change the names used for message stream between the `inpage` and `contentscript` scripts to avoid conflicts when both extensions are enabled.

Tested against Bridge UI with both extension enabled and worked fine.