### PR TITLE
(Fix) Explicit conversion of networkID to number

### DIFF
--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -1133,8 +1133,9 @@ module.exports = class MetamaskController extends EventEmitter {
     const { networkController, recentBlocksController } = this
     const { recentBlocks } = recentBlocksController.store.getState()
 
-    const networkId = networkController.store.getState().network
-    const isPOA = networkId === '77' || networkId === '99'
+    const networkIdStr = networkController.store.getState().network
+    const networkId = parseInt(networkIdStr)
+    const isPOA = networkId === 77 || networkId === 99
 
     // Return 1 gwei if using a POA network of if there are no blocks have been observed:
     if (isPOA || recentBlocks.length === 0) {


### PR DESCRIPTION
Network ID is explicitly converted to a number to calculate gas price, if for some reasons `networkController.store.getState().network` returns sometimes `number` and sometimes `string` type.

Possible fix for incorrect calculation of gas price for POA network.