### PR TITLE
Update badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # MetaMask Browser Extension
-[![Build Status](https://circleci.com/gh/MetaMask/metamask-extension.svg?style=shield&circle-token=a1ddcf3cd38e29267f254c9c59d556d513e3a1fd)](https://circleci.com/gh/MetaMask/metamask-extension) [![Coverage Status](https://coveralls.io/repos/github/MetaMask/metamask-extension/badge.svg?branch=master)](https://coveralls.io/github/MetaMask/metamask-extension?branch=master) [![Greenkeeper badge](https://badges.greenkeeper.io/MetaMask/metamask-extension.svg)](https://greenkeeper.io/) [![Stories in Ready](https://badge.waffle.io/MetaMask/metamask-extension.png?label=in%20progress&title=waffle.io)](https://waffle.io/MetaMask/metamask-extension)
+[![Build Status](https://circleci.com/gh/poanetwork/metamask-extension.svg?style=shield)](https://circleci.com/gh/poanetwork/metamask-extension) <!--[![Coverage Status](https://coveralls.io/repos/github/poanetwork/metamask-extension/badge.svg?branch=master)](https://coveralls.io/github/poanetwork/metamask-extension?branch=master) [![Greenkeeper badge](https://badges.greenkeeper.io/poanetwork/metamask-extension.svg)](https://greenkeeper.io/)--> [![Stories in Ready](https://badge.waffle.io/poanetwork/metamask-extension.png?label=in%20progress&title=waffle.io)](https://waffle.io/poanetwork/metamask-extension)
 
 ## Support
 


### PR DESCRIPTION
Update the CircleCI and Waffle badges, and comment out the coveralls and greenkeeper badges (there are not setup, we can uncomment them when they are configured).