### PR TITLE
Update sentry links to the new org account

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Current Master
 
+- [#50](https://github.com/poanetwork/metamask-extension/pull/50): Update sentry links.
 - [#45](https://github.com/poanetwork/metamask-extension/pull/45): Automate release publish.
 
 ## 4.8.2 Thu Jul 26 2018

--- a/app/scripts/lib/setupRaven.js
+++ b/app/scripts/lib/setupRaven.js
@@ -1,8 +1,8 @@
 const Raven = require('raven-js')
 const METAMASK_DEBUG = process.env.METAMASK_DEBUG
 const extractEthjsErrorMessage = require('./extractEthjsErrorMessage')
-const PROD = 'https://1cbad94ab42e4d40a17cbfee0c30e1cb@sentry.io/1246874'
-const DEV = 'https://9c6228ffe5604981b910275fbfb3fa33@sentry.io/1246875'
+const PROD = 'https://3bd485f8ed6047d882f3f010cbae46ca@sentry.io/1250701'
+const DEV = 'https://267dbd2f3447444faa637bc34bcc7317@sentry.io/1253429'
 
 module.exports = setupRaven
 


### PR DESCRIPTION
Update sentry links to use the new account.