### PR TITLE
(Fix) Update e2e test for Terms of Use page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Current Master
 
+- [#59](https://github.com/poanetwork/metamask-extension/pull/59): Update e2e test of Terms of Use page
 - [#58](https://github.com/poanetwork/metamask-extension/pull/58): Update Terms of Use page style
 - [#57](https://github.com/poanetwork/metamask-extension/pull/57): Optimized images for release.
 - [#55](https://github.com/poanetwork/metamask-extension/pull/55): Tests fix.

--- a/test/e2e/metamask.spec.js
+++ b/test/e2e/metamask.spec.js
@@ -80,9 +80,9 @@ describe('Metamask popup page', function () {
       delay(300)
     })
 
-    it('checks if the TOU button is disabled', async () => {
+    it('checks if the TOU button is enabled', async () => {
       const button = await driver.findElement(By.css('button')).isEnabled()
-      assert.equal(button, false, 'disabled continue button')
+      assert.equal(button, true, 'enabled continue button')
       const element = await driver.findElement(By.linkText('Terms of Service'))
       await driver.executeScript('arguments[0].scrollIntoView(true)', element)
       await delay(700)


### PR DESCRIPTION
`Accept` button is enabled everytime since implementing https://github.com/poanetwork/metamask-extension/pull/58. Corresponding e2e test was updated fixed to fit this change.