### PR TITLE
(Fix) Improve performance when big list of sent transactions from account

### DIFF
--- a/app/scripts/lib/ComposableObservableStore.js
+++ b/app/scripts/lib/ComposableObservableStore.js
@@ -44,6 +44,36 @@ class ComposableObservableStore extends ObservableStore {
     }
     return flatState
   }
+
+  /**
+   * Merges all child store state into a single object rather than
+   * returning an object keyed by child store class name
+   * Removes heavy objects that are not needed on UI
+   *
+   * @returns {Object} - Object containing merged child store state
+   */
+  getFilteredFlatState () {
+    let flatState = {}
+    for (const key in this.config) {
+      let nextState
+      if (key === 'RecentBlocksController') {
+        nextState = {}
+      } else if (key === 'TxController') {
+        const state = this.config[key].getState()
+        const txList = state.selectedAddressTxList.map(
+          item => ({...item, history: null, nonceDetails: null})
+        )
+        nextState = {
+          ...state,
+          selectedAddressTxList: txList,
+        }
+      } else {
+        nextState = this.config[key].getState()
+      }
+      flatState = { ...flatState, ...nextState }
+    }
+    return flatState
+  }
 }
 
 module.exports = ComposableObservableStore

--- a/app/scripts/lib/ComposableObservableStore.js
+++ b/app/scripts/lib/ComposableObservableStore.js
@@ -60,9 +60,7 @@ class ComposableObservableStore extends ObservableStore {
         nextState = {}
       } else if (key === 'TxController') {
         const state = this.config[key].getState()
-        const txList = state.selectedAddressTxList.map(
-          item => ({...item, history: null, nonceDetails: null})
-        )
+        const txList = state.selectedAddressTxList.map(item => ({...item, history: null, nonceDetails: null}))
         nextState = {
           ...state,
           selectedAddressTxList: txList,

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -322,7 +322,7 @@ module.exports = class MetamaskController extends EventEmitter {
 
     return {
       ...{ isInitialized },
-      ...this.memStore.getFlatState(),
+      ...this.memStore.getFilteredFlatState(),
       ...this.configManager.getConfig(),
       ...{
         lostAccounts: this.configManager.getLostAccounts(),


### PR DESCRIPTION
Relates to #51 

When there is an update on the state of the extension, `background` script sends the full updated state to the UI using RPC. That process involves iterating over every attribute for parsing the object, and when there are a lot of transactions (the 40 last transactions are stored as max) it blocks the thread causing slow render and responses on UI interaction. I was able to find that by profiling the extension using chrome developer tools. 

Here is an example of a profile of an Account with 40 transactions on the list: [profileNiftyWallet.zip](https://github.com/poanetwork/metamask-extension/files/2262730/profileNiftyWallet.zip)
![privatesendupdatebefore](https://user-images.githubusercontent.com/4614574/43719681-bc6a7648-9964-11e8-845d-97efddc44601.png)

In this example the `privateSendUpdate` function took more than a second to emit the state.
https://github.com/poanetwork/metamask-extension/blob/e03ecbfff2415be5d5d6a5b928114f04a1b7b4d4/app/scripts/metamask-controller.js#L1283-L1289
Here is the generated state of this example which stored in a json file size is **337,8 kb** [exampleState.zip](https://github.com/poanetwork/metamask-extension/files/2262767/exampleState.zip)

I identified that there were some parts of the state that weren't being used by the UI so I filtered them from being send to UI to improve the performance.

Information that is no longer being send to UI:
- Last 40 blocks related information.
- For every transaction: UI history and nonce related information.

After that changes, a json file with the state has a size of **44,2 kb**  [newExampleState.zip](https://github.com/poanetwork/metamask-extension/files/2262812/newExampleState.zip)

Here is an example of a new profile after the changes where `privateSendUpdate` function time was reduced. [profileImproved.zip](https://github.com/poanetwork/metamask-extension/files/2262842/profileImproved.zip)

![privatesendupdateafter](https://user-images.githubusercontent.com/4614574/43721199-92571b64-9968-11e8-83dd-db8af4c6c190.png)

Please test this solution to know if it is good enough, if not, maybe there is still place to reduce the state sent to UI or discuss any other alternatives.

 