### PR TITLE
Comment out step to publish docs from CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -346,12 +346,12 @@ jobs:
         - run:
             name: sentry sourcemaps upload
             command: npm run sentry:publish
-        - run:
-            name: github gh-pages docs publish
-            command: >
-              git config user.name metamaskbot
-              git config user.email admin@metamask.io
-              gh-pages -d docs/jsdocs
+#        - run:
+#            name: github gh-pages docs publish
+#            command: >
+#              git config user.name metamaskbot
+#              git config user.email admin@metamask.io
+#              gh-pages -d docs/jsdocs
 
   test-unit:
     docker:


### PR DESCRIPTION
Since we don't publish any docs yet, this step will always fail.