### PR TITLE
(Feature) Remove imported account

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,11 +25,11 @@ workflows:
           requires:
             - prep-deps-npm
             - prep-build
-      - test-e2e-firefox:
-          requires:
-            - prep-deps-npm
-            - prep-deps-firefox
-            - prep-build
+      # - test-e2e-firefox:
+      #     requires:
+      #       - prep-deps-npm
+      #       - prep-deps-firefox
+      #       - prep-build
       - test-unit:
           requires:
             - prep-deps-npm

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -115,7 +115,7 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: dependency-cache-{{ .Revision }}
+          key: v1.0-dependency-cache-firefox-
       - run:
           name: Download Firefox
           command: ./.circleci/scripts/firefox-download.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -115,7 +115,7 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: v1.0-dependency-cache-firefox-
+          key: dependency-cache-{{ .Revision }}
       - run:
           name: Download Firefox
           command: ./.circleci/scripts/firefox-download.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -115,12 +115,12 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: v1.0-dependency-cache-firefox-
+          key: v1.0-dependency-cache-firefox-{{ .Revision }}
       - run:
           name: Download Firefox
           command: ./.circleci/scripts/firefox-download.sh
       - save_cache:
-          key: v1.0-dependency-cache-firefox-
+          key: v1.0-dependency-cache-firefox-{{ .Revision }}
           paths:
             - firefox
 
@@ -221,7 +221,7 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: v1.0-dependency-cache-firefox-
+          key: v1.0-dependency-cache-firefox-{{ .Revision }}
       - run:
           name: Install firefox
           command: ./.circleci/scripts/firefox-install.sh
@@ -258,7 +258,7 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: v1.0-dependency-cache-firefox-
+          key: v1.0-dependency-cache-firefox-{{ .Revision }}
       - run:
           name: Install firefox
           command: ./.circleci/scripts/firefox-install.sh
@@ -372,7 +372,7 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: v1.0-dependency-cache-firefox-
+          key: v1.0-dependency-cache-firefox-{{ .Revision }}
       - run:
           name: Install firefox
           command: ./.circleci/scripts/firefox-install.sh
@@ -415,7 +415,7 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: v1.0-dependency-cache-firefox-
+          key: v1.0-dependency-cache-firefox-{{ .Revision }}
       - run:
           name: Install firefox
           command: ./.circleci/scripts/firefox-install.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,7 +56,7 @@ workflows:
             - test-lint
             - test-unit
             - test-e2e-chrome
-            - test-e2e-firefox
+#            - test-e2e-firefox
             - test-integration-mascara-chrome
             - test-integration-mascara-firefox
             - test-integration-flat-chrome
@@ -115,12 +115,12 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: v1.0-dependency-cache-firefox-{{ .Revision }}
+          key: v1.0-dependency-cache-firefox-
       - run:
           name: Download Firefox
           command: ./.circleci/scripts/firefox-download.sh
       - save_cache:
-          key: v1.0-dependency-cache-firefox-{{ .Revision }}
+          key: v1.0-dependency-cache-firefox-
           paths:
             - firefox
 
@@ -221,7 +221,7 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: v1.0-dependency-cache-firefox-{{ .Revision }}
+          key: v1.0-dependency-cache-firefox-
       - run:
           name: Install firefox
           command: ./.circleci/scripts/firefox-install.sh
@@ -258,7 +258,7 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: v1.0-dependency-cache-firefox-{{ .Revision }}
+          key: v1.0-dependency-cache-firefox-
       - run:
           name: Install firefox
           command: ./.circleci/scripts/firefox-install.sh
@@ -372,7 +372,7 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: v1.0-dependency-cache-firefox-{{ .Revision }}
+          key: v1.0-dependency-cache-firefox-
       - run:
           name: Install firefox
           command: ./.circleci/scripts/firefox-install.sh
@@ -415,7 +415,7 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: v1.0-dependency-cache-firefox-{{ .Revision }}
+          key: v1.0-dependency-cache-firefox-
       - run:
           name: Install firefox
           command: ./.circleci/scripts/firefox-install.sh

--- a/old-ui/app/app.js
+++ b/old-ui/app/app.js
@@ -36,6 +36,7 @@ const HDRestoreVaultScreen = require('./keychains/hd/restore-vault')
 const RevealSeedConfirmation = require('./keychains/hd/recover-seed/confirmation')
 const AccountDropdowns = require('./components/account-dropdowns').AccountDropdowns
 const DeleteRpc = require('./components/delete-rpc')
+const DeleteImportedAccount = require('./components/delete-imported-account')
 
 module.exports = connect(mapStateToProps)(App)
 
@@ -651,7 +652,9 @@ App.prototype.renderPrimary = function () {
     case 'delete-rpc':
       log.debug('rendering delete rpc confirmation screen')
       return h(DeleteRpc, {key: 'delete-rpc'})
-
+    case 'delete-imported-account':
+      log.debug('rendering delete imported account confirmation screen')
+      return h(DeleteImportedAccount, {key: 'delete-imported-account'})
     default:
       log.debug('rendering default, account detail screen')
       return h(AccountDetailScreen, {key: 'account-detail'})
@@ -702,7 +705,7 @@ App.prototype.renderCustomOption = function (provider) {
         },
         [h('div.selected-network'),
           label,
-          h('.remove-rpc', {
+          h('.remove', {
             onClick: (event) => {
               event.preventDefault()
               event.stopPropagation()
@@ -761,7 +764,7 @@ App.prototype.renderCommonRpc = function (rpcList, provider) {
         },
         [
           rpc,
-          h('.remove-rpc', {
+          h('.remove', {
             onClick: (event) => {
               event.preventDefault()
               event.stopPropagation()

--- a/old-ui/app/components/account-dropdowns.js
+++ b/old-ui/app/components/account-dropdowns.js
@@ -82,17 +82,32 @@ class AccountDropdowns extends Component {
             },
           }, identity.name || ''),
           this.indicateIfLoose(keyring),
+          this.ifLooseAcc(keyring) ? h('.remove', {
+            onClick: (event) => {
+              event.preventDefault()
+              event.stopPropagation()
+              this.props.actions.showDeleteImportedAccount(identity)
+              this.setState({
+                accountSelectorActive: false,
+                optionsMenuActive: false,
+              })
+            },
+          }) : null,
         ]
       )
     })
   }
 
-  indicateIfLoose (keyring) {
+  ifLooseAcc (keyring) {
     try { // Sometimes keyrings aren't loaded yet:
       const type = keyring.type
       const isLoose = type !== 'HD Key Tree'
-      return isLoose ? h('.keyring-label', 'IMPORTED') : null
+      return isLoose
     } catch (e) { return }
+  }
+
+  indicateIfLoose (keyring) {
+    return this.ifLooseAcc(keyring) ? h('.keyring-label', 'IMPORTED') : null
   }
 
   renderAccountSelector () {
@@ -104,12 +119,12 @@ class AccountDropdowns extends Component {
       {
         useCssTransition: true, // Hardcoded because account selector is temporarily in app-header
         style: {
-          marginLeft: '-198px',
+          marginLeft: '-213px',
           marginTop: '32px',
           minWidth: '180px',
           overflowY: 'auto',
           maxHeight: '300px',
-          width: '250px',
+          width: '265px',
         },
         innerStyle: {
           padding: '8px 25px',
@@ -332,6 +347,7 @@ const mapDispatchToProps = (dispatch) => {
       addNewAccount: () => dispatch(actions.addNewAccount()),
       showImportPage: () => dispatch(actions.showImportPage()),
       showQrView: (selected, identity) => dispatch(actions.showQrView(selected, identity)),
+      showDeleteImportedAccount: (identity) => dispatch(actions.showDeleteImportedAccount(identity)),
     },
   }
 }

--- a/old-ui/app/components/delete-imported-account.js
+++ b/old-ui/app/components/delete-imported-account.js
@@ -1,0 +1,84 @@
+const inherits = require('util').inherits
+const Component = require('react').Component
+const h = require('react-hyperscript')
+const connect = require('react-redux').connect
+const actions = require('../../../ui/app/actions')
+
+module.exports = connect(mapStateToProps)(DeleteImportedAccount)
+
+function mapStateToProps (state) {
+  return {
+    metamask: state.metamask,
+    identity: state.appState.identity,
+    provider: state.metamask.provider,
+  }
+}
+
+inherits(DeleteImportedAccount, Component)
+function DeleteImportedAccount () {
+  Component.call(this)
+}
+
+DeleteImportedAccount.prototype.render = function () {
+  console.log('this.props:', this.props)
+  return h('.flex-column.flex-grow', {
+    style: {
+      overflowX: 'auto',
+      overflowY: 'hidden',
+    },
+  }, [
+    // subtitle and nav
+    h('.section-title.flex-row.flex-center', [
+      h('i.fa.fa-arrow-left.fa-lg.cursor-pointer', {
+        onClick: () => {
+          this.props.dispatch(actions.showConfigPage())
+        },
+        style: {
+          position: 'absolute',
+          left: '30px',
+        },
+      }),
+      h('h2.page-subtitle', 'Delete Imported Account'),
+    ]),
+    h('div', {
+      style: {
+        margin: '0px 30px 20px',
+      },
+    },
+    h('.error', 'Be sure, that you saved a private key of JSON keystore file of this account in a safe place. Otherwise, you will not be able to restore this account.'),
+    ),
+    h('p.confirm-label', {
+        style: {
+          textAlign: 'center',
+          margin: '0px 30px 20px ',
+        },
+      },
+      `Are you sure to delete imported ${this.props.identity.name} (${this.props.identity.address})?`),
+    h('.flex-row.flex-right', {
+      style: {
+        marginRight: '30px',
+      },
+    }, [
+      h('button.btn-violet',
+        {
+          style: {
+            marginRight: '10px',
+          },
+          onClick: () => {
+            this.props.dispatch(actions.showConfigPage())
+          },
+        },
+        'No'),
+      h('button',
+        {
+          onClick: () => {
+            this.props.dispatch(actions.removeAccount(this.props.identity.address))
+              .then(() => {
+                this.props.dispatch(actions.showConfigPage())
+              })
+          },
+        },
+        'Yes'),
+    ]),
+  ])
+}

--- a/old-ui/app/components/delete-imported-account.js
+++ b/old-ui/app/components/delete-imported-account.js
@@ -45,7 +45,7 @@ DeleteImportedAccount.prototype.render = function () {
         margin: '0px 30px 20px',
       },
     },
-    h('.error', 'Be sure, that you saved a private key of JSON keystore file of this account in a safe place. Otherwise, you will not be able to restore this account.'),
+    h('.error', 'Be sure, that you saved a private key or JSON keystore file of this account in a safe place. Otherwise, you will not be able to restore this account.'),
     ),
     h('p.confirm-label', {
         style: {

--- a/old-ui/app/css/index.css
+++ b/old-ui/app/css/index.css
@@ -357,7 +357,7 @@ p.exchanges {
   background-position: right;
 }
 
-.remove-rpc {
+.remove {
   background-image: url('../images/remove.svg');
   background-size: 12px 12px;
   background-repeat: no-repeat;
@@ -988,6 +988,7 @@ div.message-container > div:first-child {
   border: solid 1px #6729a8;
   border-radius: 5px;
   background-color: rgba(103,41,168, 0.2);
+  word-wrap: break-word;
 }
 
 .contract {

--- a/old-ui/app/css/lib.css
+++ b/old-ui/app/css/lib.css
@@ -241,7 +241,7 @@ hr.horizontal-line {
   justify-content: center;
   padding: 4px;
   position: absolute;
-  right: 0;
+  right: 20px;
 }
 
 .ether-balance {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8490,12 +8490,13 @@
                     "resolved": "https://registry.npmjs.org/eth-sig-util/-/eth-sig-util-2.0.1.tgz",
                     "integrity": "sha512-lxHZOQspexk3DaGj4RBbWy4C/qNOWRnxpaJzNnYD3WEmC8shcJ4tHs7Xv878rzvILfJnSFSCCiKQhng1m80oBQ==",
                     "requires": {
+                        "ethereumjs-abi": "git+https://github.com/ethereumjs/ethereumjs-abi.git#00ba8463a7f7a67fcad737ff9c2ebd95643427f7",
                         "ethereumjs-util": "^5.1.1"
                     },
                     "dependencies": {
                         "ethereumjs-abi": {
                             "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#00ba8463a7f7a67fcad737ff9c2ebd95643427f7",
-                            "from": "git+https://github.com/ethereumjs/ethereumjs-abi.git#00ba8463a7f7a67fcad737ff9c2ebd95643427f7",
+                            "from": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
                             "requires": {
                                 "bn.js": "^4.10.0",
                                 "ethereumjs-util": "^5.0.0"
@@ -8773,12 +8774,13 @@
             "resolved": "https://registry.npmjs.org/eth-sig-util/-/eth-sig-util-1.4.2.tgz",
             "integrity": "sha1-jZWCAsftuq6Dlwf7pvCf8ydgYhA=",
             "requires": {
+                "ethereumjs-abi": "git+https://github.com/ethereumjs/ethereumjs-abi.git#00ba8463a7f7a67fcad737ff9c2ebd95643427f7",
                 "ethereumjs-util": "^5.1.1"
             },
             "dependencies": {
                 "ethereumjs-abi": {
                     "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#00ba8463a7f7a67fcad737ff9c2ebd95643427f7",
-                    "from": "git+https://github.com/ethereumjs/ethereumjs-abi.git#00ba8463a7f7a67fcad737ff9c2ebd95643427f7",
+                    "from": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
                     "requires": {
                         "bn.js": "^4.10.0",
                         "ethereumjs-util": "^5.0.0"
@@ -8820,12 +8822,14 @@
                     "integrity": "sha512-lxHZOQspexk3DaGj4RBbWy4C/qNOWRnxpaJzNnYD3WEmC8shcJ4tHs7Xv878rzvILfJnSFSCCiKQhng1m80oBQ==",
                     "dev": true,
                     "requires": {
+                        "ethereumjs-abi": "git+https://github.com/ethereumjs/ethereumjs-abi.git#00ba8463a7f7a67fcad737ff9c2ebd95643427f7",
                         "ethereumjs-util": "^5.1.1"
                     },
                     "dependencies": {
                         "ethereumjs-abi": {
                             "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#00ba8463a7f7a67fcad737ff9c2ebd95643427f7",
-                            "from": "git+https://github.com/ethereumjs/ethereumjs-abi.git#00ba8463a7f7a67fcad737ff9c2ebd95643427f7",
+                            "from": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
+                            "dev": true,
                             "requires": {
                                 "bn.js": "^4.10.0",
                                 "ethereumjs-util": "^5.0.0"
@@ -8837,6 +8841,7 @@
                     "version": "5.2.0",
                     "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-5.2.0.tgz",
                     "integrity": "sha512-CJAKdI0wgMbQFLlLRtZKGcy/L6pzVRgelIZqRqNbuVFM3K9VEnyfbcvz0ncWMRNCe4kaHWjwRYQcYMucmwsnWA==",
+                    "dev": true,
                     "requires": {
                         "bn.js": "^4.11.0",
                         "create-hash": "^1.1.2",
@@ -31021,6 +31026,7 @@
             "version": "3.1.5",
             "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
             "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
+            "dev": true,
             "requires": {
                 "is-typedarray": "^1.0.0"
             }
@@ -32044,6 +32050,7 @@
             "resolved": "https://registry.npmjs.org/web3/-/web3-0.20.3.tgz",
             "integrity": "sha1-yqRDc9yIFayHZ73ba6cwc5ZMqos=",
             "requires": {
+                "bignumber.js": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
                 "crypto-js": "^3.1.4",
                 "utf8": "^2.1.1",
                 "xhr2": "*",
@@ -32052,7 +32059,7 @@
             "dependencies": {
                 "bignumber.js": {
                     "version": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
-                    "from": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934"
+                    "from": "git+https://github.com/frozeman/bignumber.js-nolookahead.git"
                 }
             }
         },
@@ -32551,7 +32558,8 @@
             "dev": true,
             "requires": {
                 "underscore": "1.8.3",
-                "web3-core-helpers": "1.0.0-beta.34"
+                "web3-core-helpers": "1.0.0-beta.34",
+                "websocket": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2"
             },
             "dependencies": {
                 "underscore": {
@@ -32562,7 +32570,8 @@
                 },
                 "websocket": {
                     "version": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2",
-                    "from": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2",
+                    "from": "git://github.com/frozeman/WebSocket-Node.git#browserifyCompatible",
+                    "dev": true,
                     "requires": {
                         "debug": "^2.2.0",
                         "nan": "^2.3.3",
@@ -33918,7 +33927,8 @@
         "yaeti": {
             "version": "0.0.6",
             "resolved": "https://registry.npmjs.org/yaeti/-/yaeti-0.0.6.tgz",
-            "integrity": "sha1-8m9ITXJoTPQr7ft2lwqhYI+/lXc="
+            "integrity": "sha1-8m9ITXJoTPQr7ft2lwqhYI+/lXc=",
+            "dev": true
         },
         "yallist": {
             "version": "2.1.2",

--- a/ui/app/actions.js
+++ b/ui/app/actions.js
@@ -309,6 +309,8 @@ var actions = {
   SHOW_DELETE_RPC: 'SHOW_DELETE_RPC',
   showDeleteRPC,
   removeCustomRPC,
+  SHOW_DELETE_IMPORTED_ACCOUNT: 'SHOW_DELETE_IMPORTED_ACCOUNT',
+  showDeleteImportedAccount,
 }
 
 module.exports = actions
@@ -2303,5 +2305,13 @@ function removeCustomRPC (url, provider) {
         resolve(url)
       })
     })
+  }
+}
+
+function showDeleteImportedAccount (identity, keyring) {
+  return {
+    type: actions.SHOW_DELETE_IMPORTED_ACCOUNT,
+    identity,
+    keyring,
   }
 }

--- a/ui/app/reducers/app.js
+++ b/ui/app/reducers/app.js
@@ -720,6 +720,15 @@ function reduceApp (state, action) {
         RPC_URL: action.RPC_URL,
       })
 
+    case actions.SHOW_DELETE_IMPORTED_ACCOUNT:
+      return extend(appState, {
+        currentView: {
+          name: 'delete-imported-account',
+          context: appState.currentView.context,
+        },
+        identity: action.identity,
+      })
+
     default:
       return appState
   }


### PR DESCRIPTION
Relates to https://github.com/poanetwork/metamask-extension/issues/24

The ability to remove an imported account was added to the accounts' menu.
When a user clicks to `remove` icon, the confirmation screen appears.

Import and deletion of imported accounts are covered with unit tests in this PR.

![2018-08-14 13 45 36](https://user-images.githubusercontent.com/4341812/44098380-c3748944-9fe8-11e8-8f8b-749e315828ba.png)
![2018-08-14 17 40 01](https://user-images.githubusercontent.com/4341812/44098568-33570e94-9fe9-11e8-95af-b0165680a50b.png)

