### PR TITLE
(Feature) Deanonymize private network

### DIFF
--- a/old-ui/app/app.js
+++ b/old-ui/app/app.js
@@ -705,7 +705,7 @@ App.prototype.renderCustomOption = function (provider) {
           },
         },
         [h('div.selected-network'),
-          label,
+          h('.span.custom-rpc', label),
           h('.remove', {
             onClick: (event) => {
               event.preventDefault()
@@ -744,7 +744,7 @@ App.prototype.renderCommonRpc = function (rpcList, provider) {
           },
         },
         [
-          rpc,
+          h('.span.custom-rpc', rpc),
           h('.remove', {
             onClick: (event) => {
               event.preventDefault()

--- a/old-ui/app/app.js
+++ b/old-ui/app/app.js
@@ -721,7 +721,7 @@ App.prototype.renderCustomOption = function (provider) {
 
 App.prototype.getNetworkName = function () {
   const { network } = this.props
-  return ethNetProps.props.getNetworkDisplayName(parseInt(network))
+  return ethNetProps.props.getNetworkDisplayName(network)
 }
 
 App.prototype.renderCommonRpc = function (rpcList, provider) {

--- a/old-ui/app/app.js
+++ b/old-ui/app/app.js
@@ -37,6 +37,7 @@ const RevealSeedConfirmation = require('./keychains/hd/recover-seed/confirmation
 const AccountDropdowns = require('./components/account-dropdowns').AccountDropdowns
 const DeleteRpc = require('./components/delete-rpc')
 const DeleteImportedAccount = require('./components/delete-imported-account')
+const ethNetProps = require('eth-net-props')
 
 module.exports = connect(mapStateToProps)(App)
 
@@ -288,7 +289,7 @@ App.prototype.renderNetworkDropdown = function () {
         },
       },
       [h(providerType === 'poa' ? 'div.selected-network' : ''),
-        'POA Network',
+        ethNetProps.props.getNetworkDisplayName(99),
       ]
     ),
 
@@ -305,7 +306,7 @@ App.prototype.renderNetworkDropdown = function () {
         },
       },
       [h(providerType === 'sokol' ? 'div.selected-network' : ''),
-        'POA Sokol Test Network',
+        ethNetProps.props.getNetworkDisplayName(77),
       ]
     ),
 
@@ -322,7 +323,7 @@ App.prototype.renderNetworkDropdown = function () {
         },
       },
       [h(providerType === 'mainnet' ? 'div.selected-network' : ''),
-        'Main Ethereum Network',
+        ethNetProps.props.getNetworkDisplayName(1),
       ]
     ),
 
@@ -339,7 +340,7 @@ App.prototype.renderNetworkDropdown = function () {
         },
       },
       [h(providerType === 'ropsten' ? 'div.selected-network' : ''),
-        'Ropsten Test Network',
+        ethNetProps.props.getNetworkDisplayName(3),
       ]
     ),
 
@@ -356,7 +357,7 @@ App.prototype.renderNetworkDropdown = function () {
         },
       },
       [h(providerType === 'kovan' ? 'div.selected-network' : ''),
-        'Kovan Test Network',
+        ethNetProps.props.getNetworkDisplayName(42),
       ]
     ),
 
@@ -373,7 +374,7 @@ App.prototype.renderNetworkDropdown = function () {
         },
       },
       [h(providerType === 'rinkeby' ? 'div.selected-network' : ''),
-        'Rinkeby Test Network',
+        ethNetProps.props.getNetworkDisplayName(4),
       ]
     ),
 
@@ -719,28 +720,8 @@ App.prototype.renderCustomOption = function (provider) {
 }
 
 App.prototype.getNetworkName = function () {
-  const { provider } = this.props
-  const providerName = provider.type
-
-  let name
-
-  if (providerName === 'mainnet') {
-    name = 'Main Ethereum Network'
-  } else if (providerName === 'sokol') {
-    name = 'POA Sokol Test Network'
-  } else if (providerName === 'ropsten') {
-    name = 'Ropsten Test Network'
-  } else if (providerName === 'kovan') {
-    name = 'Kovan Test Network'
-  } else if (providerName === 'rinkeby') {
-    name = 'Rinkeby Test Network'
-  } else if (providerName === 'poa') {
-    name = 'POA Network'
-  } else {
-    name = 'Unknown Private Network'
-  }
-
-  return name
+  const { network } = this.props
+  return ethNetProps.props.getNetworkDisplayName(parseInt(network))
 }
 
 App.prototype.renderCommonRpc = function (rpcList, provider) {

--- a/old-ui/app/components/network.js
+++ b/old-ui/app/components/network.js
@@ -1,6 +1,7 @@
 const Component = require('react').Component
 const h = require('react-hyperscript')
 const inherits = require('util').inherits
+const ethNetProps = require('eth-net-props')
 
 module.exports = Network
 
@@ -12,14 +13,14 @@ function Network () {
 
 Network.prototype.render = function () {
   const props = this.props
-  const networkNumber = props.network
+  const { provider, network: networkNumber } = props
   let providerName
   try {
-    providerName = props.provider.type
+    providerName = provider.type
   } catch (e) {
     providerName = null
   }
-  let iconName, hoverText
+  let displayName, hoverText
 
   if (networkNumber === 'loading') {
     return h('span.pointer', {
@@ -40,30 +41,29 @@ Network.prototype.render = function () {
       }),
       h('i.fa.fa-caret-down'),
     ])
-  } else if (providerName === 'mainnet') {
-    hoverText = 'Main Ethereum Network'
-    iconName = 'ethereum-network'
-  } else if (providerName === 'ropsten') {
-    hoverText = 'Ropsten Test Network'
-    iconName = 'ropsten-test-network'
-  } else if (providerName === 'sokol') {
-    hoverText = 'POA Sokol Test Network'
-    iconName = 'sokol-test-network'
-  } else if (parseInt(networkNumber) === 3) {
-    hoverText = 'Ropsten Test Network'
-    iconName = 'ropsten-test-network'
-  } else if (providerName === 'kovan') {
-    hoverText = 'Kovan Test Network'
-    iconName = 'kovan-test-network'
-  } else if (providerName === 'rinkeby') {
-    hoverText = 'Rinkeby Test Network'
-    iconName = 'rinkeby-test-network'
-  } else if (providerName === 'poa') {
-    hoverText = 'POA Network'
-    iconName = 'poa-network'
   } else {
-    hoverText = 'Unknown Private Network'
-    iconName = 'unknown-private-network'
+    if (providerName === 'mainnet') {
+      displayName = 'Main Network'
+      hoverText = ethNetProps.props.getNetworkDisplayName(parseInt(networkNumber))
+    } else if (providerName === 'ropsten' || parseInt(networkNumber) === 3) {
+      displayName = 'Ropsten Test Net'
+      hoverText = ethNetProps.props.getNetworkDisplayName(parseInt(networkNumber))
+    } else if (providerName === 'sokol') {
+      displayName = 'Sokol Network'
+      hoverText = ethNetProps.props.getNetworkDisplayName(parseInt(networkNumber))
+    } else if (providerName === 'kovan') {
+      displayName = 'Kovan Test Net'
+      hoverText = ethNetProps.props.getNetworkDisplayName(parseInt(networkNumber))
+    } else if (providerName === 'rinkeby') {
+      displayName = 'Rinkeby Test Net'
+      hoverText = ethNetProps.props.getNetworkDisplayName(parseInt(networkNumber))
+    } else if (providerName === 'poa') {
+      displayName = 'POA Network'
+      hoverText = ethNetProps.props.getNetworkDisplayName(parseInt(networkNumber))
+    } else {
+      hoverText = (provider.type === 'rpc') ? `Private Network (${provider.rpcTarget})` : `Private Network (${provider.type})`
+      displayName = 'Private Network'
+    }
   }
 
   return (
@@ -73,51 +73,11 @@ Network.prototype.render = function () {
       onClick: (event) => props.onClick && props.onClick(event),
     }, [
       (function () {
-        switch (iconName) {
-          case 'ethereum-network':
-            return h(props.isUnlocked ? '.network-indicator' : '.network-indicator.hidden', [
-              h('.network-name',
-              'Main Network'),
-              props.onClick && h('i.fa.fa-caret-down.fa-lg'),
-            ])
-          case 'sokol-test-network':
-            return h(props.isUnlocked ? '.network-indicator' : '.network-indicator.hidden', [
-              h('.network-name',
-              'Sokol Network'),
-              props.onClick && h('i.fa.fa-caret-down.fa-lg'),
-            ])
-          case 'ropsten-test-network':
-            return h(props.isUnlocked ? '.network-indicator' : '.network-indicator.hidden', [
-              h('.network-name',
-              'Ropsten Test Net'),
-              props.onClick && h('i.fa.fa-caret-down.fa-lg'),
-            ])
-          case 'kovan-test-network':
-            return h(props.isUnlocked ? '.network-indicator' : '.network-indicator.hidden', [
-              h('.network-name',
-              'Kovan Test Net'),
-              props.onClick && h('i.fa.fa-caret-down.fa-lg'),
-            ])
-          case 'rinkeby-test-network':
-            return h(props.isUnlocked ? '.network-indicator' : '.network-indicator.hidden', [
-              h('.network-name',
-              'Rinkeby Test Net'),
-              props.onClick && h('i.fa.fa-caret-down.fa-lg'),
-            ])
-          case 'poa-network':
-            return h(props.isUnlocked ? '.network-indicator' : '.network-indicator.hidden', [
-              h('.network-name',
-              'POA Network'),
-              props.onClick && h('i.fa.fa-caret-down.fa-lg'),
-            ])
-          default:
-            return h(props.isUnlocked ? '.network-indicator' : '.network-indicator.hidden', [
-
-              h('.network-name',
-              'Private Network'),
-              props.onClick && h('i.fa.fa-caret-down.fa-lg'),
-            ])
-        }
+        return h(props.isUnlocked ? '.network-indicator' : '.network-indicator.hidden', [
+          h('.network-name',
+          displayName),
+          props.onClick && h('i.fa.fa-caret-down.fa-lg'),
+        ])
       })(),
     ])
   )

--- a/old-ui/app/components/network.js
+++ b/old-ui/app/components/network.js
@@ -44,22 +44,22 @@ Network.prototype.render = function () {
   } else {
     if (providerName === 'mainnet') {
       displayName = 'Main Network'
-      hoverText = ethNetProps.props.getNetworkDisplayName(parseInt(networkNumber))
+      hoverText = ethNetProps.props.getNetworkDisplayName(networkNumber)
     } else if (providerName === 'ropsten' || parseInt(networkNumber) === 3) {
       displayName = 'Ropsten Test Net'
-      hoverText = ethNetProps.props.getNetworkDisplayName(parseInt(networkNumber))
+      hoverText = ethNetProps.props.getNetworkDisplayName(networkNumber)
     } else if (providerName === 'sokol') {
       displayName = 'Sokol Network'
-      hoverText = ethNetProps.props.getNetworkDisplayName(parseInt(networkNumber))
+      hoverText = ethNetProps.props.getNetworkDisplayName(networkNumber)
     } else if (providerName === 'kovan') {
       displayName = 'Kovan Test Net'
-      hoverText = ethNetProps.props.getNetworkDisplayName(parseInt(networkNumber))
+      hoverText = ethNetProps.props.getNetworkDisplayName(networkNumber)
     } else if (providerName === 'rinkeby') {
       displayName = 'Rinkeby Test Net'
-      hoverText = ethNetProps.props.getNetworkDisplayName(parseInt(networkNumber))
+      hoverText = ethNetProps.props.getNetworkDisplayName(networkNumber)
     } else if (providerName === 'poa') {
       displayName = 'POA Network'
-      hoverText = ethNetProps.props.getNetworkDisplayName(parseInt(networkNumber))
+      hoverText = ethNetProps.props.getNetworkDisplayName(networkNumber)
     } else {
       hoverText = (provider.type === 'rpc') ? `Private Network (${provider.rpcTarget})` : `Private Network (${provider.type})`
       displayName = 'Private Network'

--- a/old-ui/app/config.js
+++ b/old-ui/app/config.js
@@ -9,6 +9,7 @@ const infuraCurrencies = require('./infura-conversion.json').objects.sort((a, b)
 const validUrl = require('valid-url')
 const exportAsFile = require('./util').exportAsFile
 const Modal = require('../../ui/app/components/modals/index').Modal
+const ethNetProps = require('eth-net-props')
 
 module.exports = connect(mapStateToProps)(ConfigScreen)
 
@@ -257,32 +258,32 @@ function currentProviderDisplay (metamaskState, state) {
 
     case 'mainnet':
       title = 'Current Network'
-      value = 'Main Ethereum Network'
+      value = ethNetProps.props.getNetworkDisplayName(1)
       break
 
     case 'sokol':
       title = 'Current Network'
-      value = 'POA Sokol Test Network'
+      value = ethNetProps.props.getNetworkDisplayName(77)
       break
 
     case 'ropsten':
       title = 'Current Network'
-      value = 'Ropsten Test Network'
+      value = ethNetProps.props.getNetworkDisplayName(3)
       break
 
     case 'kovan':
       title = 'Current Network'
-      value = 'Kovan Test Network'
+      value = ethNetProps.props.getNetworkDisplayName(42)
       break
 
     case 'rinkeby':
       title = 'Current Network'
-      value = 'Rinkeby Test Network'
+      value = ethNetProps.props.getNetworkDisplayName(4)
       break
 
     case 'poa':
       title = 'Current Network'
-      value = 'POA Network'
+      value = ethNetProps.props.getNetworkDisplayName(99)
       break
 
     default:

--- a/old-ui/app/css/index.css
+++ b/old-ui/app/css/index.css
@@ -701,6 +701,12 @@ input.large-input {
   display: inline-block;
 }
 
+.custom-rpc {
+  width: 210px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
 /* buy eth warning screen */
 .custom-radios {
   justify-content: space-around;

--- a/package-lock.json
+++ b/package-lock.json
@@ -8750,9 +8750,9 @@
             }
         },
         "eth-net-props": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/eth-net-props/-/eth-net-props-1.0.0.tgz",
-            "integrity": "sha512-3LCXji5dFr2fY295WyUX+HJ9dYvKOg7SIPlshorVnNleuNKYTRTV3PYVsiRs/vdp2Y1TZRXig/gyCYzVxFV8vg==",
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/eth-net-props/-/eth-net-props-1.0.1.tgz",
+            "integrity": "sha512-OrDKzCMfMxNpfp7DxIfTf7NFqpu2Pkfm/9fWvt92mSW5+cJ1mEGWmKxfTNfhUPth7wlRTk4K5/NeRs4RA1IZRg==",
             "requires": {
                 "chai": "^4.1.2"
             }

--- a/package-lock.json
+++ b/package-lock.json
@@ -8750,9 +8750,9 @@
             }
         },
         "eth-net-props": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/eth-net-props/-/eth-net-props-1.0.1.tgz",
-            "integrity": "sha512-OrDKzCMfMxNpfp7DxIfTf7NFqpu2Pkfm/9fWvt92mSW5+cJ1mEGWmKxfTNfhUPth7wlRTk4K5/NeRs4RA1IZRg==",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/eth-net-props/-/eth-net-props-1.0.2.tgz",
+            "integrity": "sha512-lstMFwDb3GU3mUmWi1aGT+JlcK2qf54E+edE5x6uLrJEPr9ZYrFCuTaXyXZU8R1CEHTSaDtwRB7iTyTBVsIzoQ==",
             "requires": {
                 "chai": "^4.1.2"
             }

--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "eth-json-rpc-filters": "^1.2.6",
     "eth-json-rpc-infura": "^3.0.0",
     "eth-method-registry": "^1.0.0",
-    "eth-net-props": "^1.0.0",
+    "eth-net-props": "^1.0.1",
     "eth-phishing-detect": "^1.1.4",
     "eth-query": "^2.1.2",
     "eth-sig-util": "^1.4.2",

--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "eth-json-rpc-filters": "^1.2.6",
     "eth-json-rpc-infura": "^3.0.0",
     "eth-method-registry": "^1.0.0",
-    "eth-net-props": "^1.0.1",
+    "eth-net-props": "^1.0.2",
     "eth-phishing-detect": "^1.1.4",
     "eth-query": "^2.1.2",
     "eth-sig-util": "^1.4.2",


### PR DESCRIPTION
Relates to https://github.com/poanetwork/metamask-extension/issues/28

- `Private network (RPC endpoint URL)` text appears in the hover on custom network's title in the left corner of extension
- All display names of networks are taken now from `eth-net-props` npm package (related change in the package https://github.com/poanetwork/eth-net-props/commit/b529513b1a7950336a7a4f97f15dab42e638429a)