### PR TITLE
(Fix) Empty pending tx screen after logout/login

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,12 @@
 
 ## Current Master
 
+- [#93](https://github.com/poanetwork/metamask-extension/pull/93): (Fix) Empty pending tx screen after logout/login
 - [#91](https://github.com/poanetwork/metamask-extension/pull/91): (Fix) Confirm tx notification popup: network name
 - [#89](https://github.com/poanetwork/metamask-extension/pull/89): (Feature) Support of token per network basis
 - [#85](https://github.com/poanetwork/metamask-extension/pull/85): (Upgrade) node, npm packages versions
 - [#84](https://github.com/poanetwork/metamask-extension/pull/84): (Fix) Change green color
-- [#83](https://github.com/poanetwork/metamask-extension/pull/83): (Feature) Changing of password
+- [#83](https://github.com/poanetwork/metamask-extension/pull/83), [#92](https://github.com/poanetwork/metamask-extension/pull/92): (Feature) Changing of password
 - [#81](https://github.com/poanetwork/metamask-extension/pull/81): (Feature) Deanonymize private network
 - [#80](https://github.com/poanetwork/metamask-extension/pull/80): (Feature) Remove imported account
 - [#78](https://github.com/poanetwork/metamask-extension/pull/78): (Fix) Link to POA explorer for POA networks

--- a/old-ui/app/app.js
+++ b/old-ui/app/app.js
@@ -168,16 +168,6 @@ App.prototype.renderAppBar = function () {
           height: '38px',
           position: 'relative',
           zIndex: 12,
-          /* borderBottom: (
-            props.currentView.name === 'config' ||
-            props.currentView.name === 'add-token' ||
-            props.currentView.name === 'info' ||
-            props.currentView.name === 'qr' ||
-            props.currentView.name === 'reveal-seed-conf' ||
-            props.currentView.name === 'createVaultComplete' ||
-            props.currentView.name === 'restoreVault' ||
-            props.currentView.name === 'import-menu'
-          ) ? '1px solid #e2e2e2' : 'none',*/
         },
       }, [
 

--- a/old-ui/app/components/mini-account-panel.js
+++ b/old-ui/app/components/mini-account-panel.js
@@ -53,7 +53,6 @@ AccountPanel.prototype.genIcon = function (seed, picOrder) {
       h('i.contract', {
         style: {
           fontSize: '42px',
-          transform: 'translate(0px, -16px)',
         },
       }),
     ])

--- a/old-ui/app/components/pending-tx.js
+++ b/old-ui/app/components/pending-tx.js
@@ -44,7 +44,7 @@ function mapStateToProps (state) {
     unapprovedMsgs: state.metamask.unapprovedMsgs,
     unapprovedPersonalMsgs: state.metamask.unapprovedPersonalMsgs,
     unapprovedTypedMessages: state.metamask.unapprovedTypedMessages,
-    index: state.appState.currentView.context,
+    index: state.appState.currentView.pendingTxIndex || 0,
     warning: state.appState.warning,
     network: state.metamask.network,
     provider: state.metamask.provider,
@@ -519,7 +519,7 @@ PendingTx.prototype.miniAccountPanelForRecipient = function () {
       ])
   } else {
     return h(MiniAccountPanel, {
-      picOrder: 'left',
+      picOrder: 'right',
     }, [
 
       h('span.font-small', {

--- a/old-ui/app/conf-tx.js
+++ b/old-ui/app/conf-tx.js
@@ -24,7 +24,7 @@ function mapStateToProps (state) {
     unapprovedMsgs: state.metamask.unapprovedMsgs,
     unapprovedPersonalMsgs: state.metamask.unapprovedPersonalMsgs,
     unapprovedTypedMessages: state.metamask.unapprovedTypedMessages,
-    index: state.appState.currentView.context,
+    index: state.appState.currentView.pendingTxIndex || 0,
     warning: state.appState.warning,
     network: state.metamask.network,
     provider: state.metamask.provider,
@@ -52,8 +52,8 @@ ConfirmTxScreen.prototype.render = function () {
   }
 
   var unconfTxList = txHelper(unapprovedTxs, unapprovedMsgs, unapprovedPersonalMsgs, unapprovedTypedMessages, network)
-
-  var txData = unconfTxList[props.index] || {}
+  const ind = props.index || 0
+  var txData = unconfTxList[ind] || {}
   var txParams = txData.params || {}
 
   log.info(`rendering a combined ${unconfTxList.length} unconf msg & txs`)

--- a/old-ui/app/css/index.css
+++ b/old-ui/app/css/index.css
@@ -532,8 +532,6 @@ input.large-input {
 }
 
 .identity-panel .identicon-wrapper {
-  margin-bottom: 10px;
-  margin-top: 10px;
   display: flex;
   align-items: center;
 }
@@ -547,8 +545,7 @@ input.large-input {
 }
 
 .identity-panel i {
-  margin-top: 32px;
-  margin-right: 6px;
+  margin-left: 6px;
   color: #ffffff;
 }
 

--- a/ui/app/reducers/app.js
+++ b/ui/app/reducers/app.js
@@ -67,6 +67,8 @@ function reduceApp (state, action) {
     gasIsLoading: false,
   }, state.appState)
 
+  let curPendingTxIndex = appState.currentView.pendingTxIndex || 0
+
   switch (action.type) {
     // dropdown methods
     case actions.NETWORK_DROPDOWN_OPEN:
@@ -425,7 +427,7 @@ function reduceApp (state, action) {
       return extend(appState, {
         currentView: {
           name: 'confTx',
-          context: action.id ? indexForPending(state, action.id) : 0,
+          pendingTxIndex: action.id ? indexForPending(state, action.id) : 0,
         },
         transForward: action.transForward,
         warning: null,
@@ -481,18 +483,18 @@ function reduceApp (state, action) {
         transForward: true,
         currentView: {
           name: 'confTx',
-          context: ++appState.currentView.context,
+          pendingTxIndex: ++curPendingTxIndex,
           warning: null,
         },
       })
 
     case actions.VIEW_PENDING_TX:
-      const context = indexForPending(state, action.value)
+      const pendingTxIndex = indexForPending(state, action.value)
       return extend(appState, {
         transForward: true,
         currentView: {
           name: 'confTx',
-          context,
+          pendingTxIndex,
           warning: null,
         },
       })
@@ -502,7 +504,7 @@ function reduceApp (state, action) {
         transForward: false,
         currentView: {
           name: 'confTx',
-          context: --appState.currentView.context,
+          pendingTxIndex: --curPendingTxIndex,
           warning: null,
         },
       })


### PR DESCRIPTION
Relates to  https://github.com/poanetwork/metamask-extension/issues/68

The root cause of the issue is that `context` prop contains not the index of pending tx, but the context from the previous screen (current unlocked address), when we attempt to login after logout.

Solution:

- `context` prop is replaced with `pendingTxIndex` prop.
- if `pendingTxIndex` is `undefined`, as in the case from logout/login, it is set to 0. So, the first pending tx will be displayed in the list, if pending txs exist.

Also, view of pending contract creation screen is configured to match the style of pending screen:
Before:

![2018-08-23 17 22 03](https://user-images.githubusercontent.com/4341812/44531293-1b4e8b80-a6f9-11e8-94f5-e5ffcb02b30a.png)


After:

![2018-08-23 16 58 38](https://user-images.githubusercontent.com/4341812/44531118-a418f780-a6f8-11e8-8b3f-2ff425c55b06.png)
