### PR TITLE
(Fix) Force open notification popup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Current Master
 
+- [#94](https://github.com/poanetwork/metamask-extension/pull/94): (Fix) Force open notification popup
 - [#91](https://github.com/poanetwork/metamask-extension/pull/91): (Fix) Confirm tx notification popup: network name
 - [#89](https://github.com/poanetwork/metamask-extension/pull/89): (Feature) Support of token per network basis
 - [#85](https://github.com/poanetwork/metamask-extension/pull/85): (Upgrade) node, npm packages versions

--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -434,7 +434,13 @@ function setupController (initState, initLangCode) {
 function triggerUi () {
   extension.tabs.query({ active: true }, tabs => {
     const currentlyActiveMetamaskTab = Boolean(tabs.find(tab => openMetamaskTabsIDs[tab.id]))
-    if (!popupIsOpen && !currentlyActiveMetamaskTab && !notificationIsOpen) {
+    /**
+     * https://github.com/poanetwork/metamask-extension/issues/19
+     * !notificationIsOpen was removed from the check, because notification can be opened, but it can be behind the DApp
+     * for some reasons. For example, if notification popup was opened, but user moved focus to DApp.
+     * New transaction, in this case, will not appear in front of DApp.
+     */
+    if (!popupIsOpen && !currentlyActiveMetamaskTab) {
       notificationManager.showPopup()
     }
   })

--- a/app/scripts/lib/notification-manager.js
+++ b/app/scripts/lib/notification-manager.js
@@ -26,7 +26,7 @@ class NotificationManager {
         // bring focus to existing chrome popup
         extension.windows.update(popup.id, { focused: true })
       } else {
-        const cb = (currentPopup) => { 
+        const cb = (currentPopup) => {
           this._popupId = currentPopup.id
           extension.windows.update(currentPopup.id, { focused: true })
         }

--- a/app/scripts/lib/notification-manager.js
+++ b/app/scripts/lib/notification-manager.js
@@ -26,7 +26,10 @@ class NotificationManager {
         // bring focus to existing chrome popup
         extension.windows.update(popup.id, { focused: true })
       } else {
-        const cb = (currentPopup) => { this._popupId = currentPopup.id }
+        const cb = (currentPopup) => { 
+          this._popupId = currentPopup.id
+          extension.windows.update(currentPopup.id, { focused: true })
+        }
         // create new notification popup
         const creation = extension.windows.create({
           url: 'notification.html',

--- a/app/scripts/platforms/extension.js
+++ b/app/scripts/platforms/extension.js
@@ -22,7 +22,7 @@ class ExtensionPlatform {
 
   /**
    * Closes all notifications windows, when action is confirmed in popup
-   * or closes notification window itself, wheb action is confirmed from it
+   * or closes notification window itself, when action is confirmed from it
    */
   closeNotificationWindow () {
     return extension.windows.getCurrent((curWindowsDetails) => {

--- a/app/scripts/platforms/extension.js
+++ b/app/scripts/platforms/extension.js
@@ -25,16 +25,8 @@ class ExtensionPlatform {
       if (curWindowsDetails.type === 'popup') {
         return extension.windows.remove(curWindowsDetails.id)
       } else {
-        // console.log('### curWindowsDetails ###')
-        // console.log(curWindowsDetails)
         extension.windows.getAll((windowsDetails) => {
-          // console.log('### windowsDetails ###')
-          // console.log(windowsDetails)
-          const windowsDetailsFiltered = windowsDetails.filter((windowDetails) => windowDetails.id != curWindowsDetails.id)
-          // console.log('### windowsDetailsFiltered ###')
-          // console.log(windowsDetailsFiltered)
-          //extension.windows.update(windowsDetailsFiltered[0].id, {focused:true});
-          // return extension.windows.remove(windowsDetailsFiltered[0].id)
+          const windowsDetailsFiltered = windowsDetails.filter((windowDetails) => windowDetails.id !== curWindowsDetails.id)
           return windowsDetailsFiltered.forEach((windowDetails) => {
             if (windowDetails.type === 'popup') {
               extension.windows.remove(windowDetails.id)

--- a/app/scripts/platforms/extension.js
+++ b/app/scripts/platforms/extension.js
@@ -20,6 +20,31 @@ class ExtensionPlatform {
     })
   }
 
+  closeNotificationWindow () {
+    return extension.windows.getCurrent((curWindowsDetails) => {
+      if (curWindowsDetails.type === 'popup') {
+        return extension.windows.remove(curWindowsDetails.id)
+      } else {
+        // console.log('### curWindowsDetails ###')
+        // console.log(curWindowsDetails)
+        extension.windows.getAll((windowsDetails) => {
+          // console.log('### windowsDetails ###')
+          // console.log(windowsDetails)
+          const windowsDetailsFiltered = windowsDetails.filter((windowDetails) => windowDetails.id != curWindowsDetails.id)
+          // console.log('### windowsDetailsFiltered ###')
+          // console.log(windowsDetailsFiltered)
+          //extension.windows.update(windowsDetailsFiltered[0].id, {focused:true});
+          // return extension.windows.remove(windowsDetailsFiltered[0].id)
+          return windowsDetailsFiltered.forEach((windowDetails) => {
+            if (windowDetails.type === 'popup') {
+              extension.windows.remove(windowDetails.id)
+            }
+          })
+        })
+      }
+    })
+  }
+
   getVersion () {
     return extension.runtime.getManifest().version
   }

--- a/app/scripts/platforms/extension.js
+++ b/app/scripts/platforms/extension.js
@@ -20,6 +20,10 @@ class ExtensionPlatform {
     })
   }
 
+  /**
+   * Closes all notifications windows, when action is confirmed in popup
+   * or closes notification window itself, wheb action is confirmed from it
+   */
   closeNotificationWindow () {
     return extension.windows.getCurrent((curWindowsDetails) => {
       if (curWindowsDetails.type === 'popup') {

--- a/ui/app/actions.js
+++ b/ui/app/actions.js
@@ -10,7 +10,6 @@ const {
 const ethUtil = require('ethereumjs-util')
 const { fetchLocale } = require('../i18n-helper')
 const log = require('loglevel')
-const { ENVIRONMENT_TYPE_NOTIFICATION } = require('../../app/scripts/lib/enums')
 const { hasUnconfirmedTransactions } = require('./helpers/confirm-transaction/util')
 
 var actions = {
@@ -1280,7 +1279,10 @@ function cancelAllTx (txsData) {
     txsData.forEach((txData, i) => {
       background.cancelTransaction(txData.id, () => {
         dispatch(actions.completedTx(txData.id))
-        i === txsData.length - 1 ? dispatch(actions.goHome()) : null
+        if (i === txsData.length - 1) {
+          dispatch(actions.goHome())
+          global.platform.closeNotificationWindow()
+        }
       })
     })
   }

--- a/ui/app/actions.js
+++ b/ui/app/actions.js
@@ -793,9 +793,8 @@ function signMsg (msgData) {
 
         dispatch(actions.completedTx(msgData.metamaskId))
 
-        if (global.METAMASK_UI_TYPE === ENVIRONMENT_TYPE_NOTIFICATION &&
-          !hasUnconfirmedTransactions(getState())) {
-          return global.platform.closeCurrentWindow()
+        if (!hasUnconfirmedTransactions(getState())) {
+          return global.platform.closeNotificationWindow()
         }
 
         return resolve(msgData)
@@ -824,9 +823,8 @@ function signPersonalMsg (msgData) {
 
         dispatch(actions.completedTx(msgData.metamaskId))
 
-        if (global.METAMASK_UI_TYPE === ENVIRONMENT_TYPE_NOTIFICATION &&
-          !hasUnconfirmedTransactions(getState())) {
-          return global.platform.closeCurrentWindow()
+        if (!hasUnconfirmedTransactions(getState())) {
+          return global.platform.closeNotificationWindow()
         }
 
         return resolve(msgData)
@@ -855,9 +853,8 @@ function signTypedMsg (msgData) {
 
         dispatch(actions.completedTx(msgData.metamaskId))
 
-        if (global.METAMASK_UI_TYPE === ENVIRONMENT_TYPE_NOTIFICATION &&
-          !hasUnconfirmedTransactions(getState())) {
-          return global.platform.closeCurrentWindow()
+        if (!hasUnconfirmedTransactions(getState())) {
+          return global.platform.closeNotificationWindow()
         }
 
         return resolve(msgData)
@@ -1062,9 +1059,8 @@ function sendTx (txData) {
       }
       dispatch(actions.completedTx(txData.id))
 
-      if (global.METAMASK_UI_TYPE === ENVIRONMENT_TYPE_NOTIFICATION &&
-        !hasUnconfirmedTransactions(getState())) {
-        return global.platform.closeCurrentWindow()
+      if (!hasUnconfirmedTransactions(getState())) {
+        return global.platform.closeNotificationWindow()
       }
     })
   }
@@ -1140,9 +1136,8 @@ function updateAndApproveTx (txData) {
         dispatch(actions.completedTx(txData.id))
         dispatch(actions.hideLoadingIndication())
 
-        if (global.METAMASK_UI_TYPE === ENVIRONMENT_TYPE_NOTIFICATION &&
-          !hasUnconfirmedTransactions(getState())) {
-          return global.platform.closeCurrentWindow()
+        if (!hasUnconfirmedTransactions(getState())) {
+          return global.platform.closeNotificationWindow()
         }
 
         return txData
@@ -1188,9 +1183,8 @@ function cancelMsg (msgData) {
 
         dispatch(actions.completedTx(msgData.id))
 
-        if (global.METAMASK_UI_TYPE === ENVIRONMENT_TYPE_NOTIFICATION &&
-          !hasUnconfirmedTransactions(getState())) {
-          return global.platform.closeCurrentWindow()
+        if (!hasUnconfirmedTransactions(getState())) {
+          return global.platform.closeNotificationWindow()
         }
 
         return resolve(msgData)
@@ -1215,9 +1209,8 @@ function cancelPersonalMsg (msgData) {
 
         dispatch(actions.completedTx(id))
 
-        if (global.METAMASK_UI_TYPE === ENVIRONMENT_TYPE_NOTIFICATION &&
-          !hasUnconfirmedTransactions(getState())) {
-          return global.platform.closeCurrentWindow()
+        if (!hasUnconfirmedTransactions(getState())) {
+          return global.platform.closeNotificationWindow()
         }
 
         return resolve(msgData)
@@ -1242,9 +1235,8 @@ function cancelTypedMsg (msgData) {
 
         dispatch(actions.completedTx(id))
 
-        if (global.METAMASK_UI_TYPE === ENVIRONMENT_TYPE_NOTIFICATION &&
-          !hasUnconfirmedTransactions(getState())) {
-          return global.platform.closeCurrentWindow()
+        if (!hasUnconfirmedTransactions(getState())) {
+          return global.platform.closeNotificationWindow()
         }
 
         return resolve(msgData)
@@ -1274,9 +1266,8 @@ function cancelTx (txData) {
         dispatch(actions.completedTx(txData.id))
         dispatch(actions.hideLoadingIndication())
 
-        if (global.METAMASK_UI_TYPE === ENVIRONMENT_TYPE_NOTIFICATION &&
-          !hasUnconfirmedTransactions(getState())) {
-          return global.platform.closeCurrentWindow()
+        if (!hasUnconfirmedTransactions(getState())) {
+          return global.platform.closeNotificationWindow()
         }
 
         return txData


### PR DESCRIPTION
Relates to https://github.com/poanetwork/metamask-extension/issues/19

- Force focus to notification popup if it is already opened because it can be hidden behind the DApp
- Close notification window if action was confirmed in the popup or from notification window itself
- Close notification window if all transactions were rejected at once from the popup or from notification window itself.