### PR TITLE
(Fix) Catch Promises errors

### DIFF
--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -508,11 +508,7 @@ module.exports = class MetamaskController extends EventEmitter {
    * @returns {Promise<object>} - The keyringController update.
    */
   async submitPassword (password) {
-    try {
-      await this.keyringController.submitPassword(password)
-    } catch (err) {
-      return Promise.reject(err)
-    }
+    await this.keyringController.submitPassword(password)
     const accounts = await this.keyringController.getAccounts()
 
     // verify keyrings

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -508,7 +508,11 @@ module.exports = class MetamaskController extends EventEmitter {
    * @returns {Promise<object>} - The keyringController update.
    */
   async submitPassword (password) {
-    await this.keyringController.submitPassword(password)
+    try {
+      await this.keyringController.submitPassword(password)
+    } catch (err) {
+      return Promise.reject(err)
+    }
     const accounts = await this.keyringController.getAccounts()
 
     // verify keyrings

--- a/old-ui/app/components/confirm-change-password.js
+++ b/old-ui/app/components/confirm-change-password.js
@@ -117,31 +117,36 @@ ConfirmChangePassword.prototype.createOnEnter = function (event) {
 }
 
 ConfirmChangePassword.prototype.ChangePassword = function () {
-  const oldPasswordBox = this.refs.OldPasswordBox
+  const { props, refs } = this
+  const oldPasswordBox = refs.OldPasswordBox
   const oldPassword = oldPasswordBox.value
-  const newPasswordBox = this.refs.NewPasswordBox
+  const newPasswordBox = refs.NewPasswordBox
   const newPassword = newPasswordBox.value
-  const newPasswordConfirmBox = this.refs.PasswordBoxConfirm
+  const newPasswordConfirmBox = refs.PasswordBoxConfirm
   const newPasswordConfirm = newPasswordConfirmBox.value
 
   if (newPassword.length < 8) {
     this.warning = 'Password not long enough'
 
-    this.props.dispatch(actions.displayWarning(this.warning))
+    props.dispatch(actions.displayWarning(this.warning))
     return
   }
   if (newPassword !== newPasswordConfirm) {
     this.warning = 'Passwords don\'t match'
-    this.props.dispatch(actions.displayWarning(this.warning))
+    props.dispatch(actions.displayWarning(this.warning))
     return
   }
   if (newPassword === oldPassword) {
     this.warning = 'New password should differ from the current one'
-    this.props.dispatch(actions.displayWarning(this.warning))
+    props.dispatch(actions.displayWarning(this.warning))
     return
   }
-  this.props.dispatch(actions.changePassword(oldPassword, newPassword))
+  props.dispatch(actions.changePassword(oldPassword, newPassword))
     .then(() => {
-      this.props.dispatch(actions.showConfigPage())
+      props.dispatch(actions.showConfigPage())
+    })
+    .catch((err) => {
+      this.warning = err
+      props.dispatch(actions.displayWarning(this.warning))
     })
 }

--- a/old-ui/app/unlock.js
+++ b/old-ui/app/unlock.js
@@ -4,6 +4,7 @@ const h = require('react-hyperscript')
 const connect = require('react-redux').connect
 const actions = require('../../ui/app/actions')
 const getCaretCoordinates = require('textarea-caret')
+const log = require('loglevel')
 const EventEmitter = require('events').EventEmitter
 
 // const Mascot = require('./components/mascot')
@@ -93,10 +94,14 @@ UnlockScreen.prototype.componentDidMount = function () {
   document.getElementById('password-box').focus()
 }
 
-UnlockScreen.prototype.onSubmit = function (event) {
+UnlockScreen.prototype.onSubmit = async function (event) {
   const input = document.getElementById('password-box')
   const password = input.value
-  this.props.dispatch(actions.tryUnlockMetamask(password))
+  try {
+    await this.props.dispatch(actions.tryUnlockMetamask(password))
+  } catch(e) {
+    log.info(e)
+  }
 }
 
 UnlockScreen.prototype.onKeyPress = function (event) {
@@ -105,12 +110,16 @@ UnlockScreen.prototype.onKeyPress = function (event) {
   }
 }
 
-UnlockScreen.prototype.submitPassword = function (event) {
+UnlockScreen.prototype.submitPassword = async function (event) {
   var element = event.target
   var password = element.value
   // reset input
   element.value = ''
-  this.props.dispatch(actions.tryUnlockMetamask(password))
+  try {
+    await this.props.dispatch(actions.tryUnlockMetamask(password))
+  } catch(e) {
+    log.info(e)
+  }
 }
 
 UnlockScreen.prototype.inputChanged = function (event) {

--- a/old-ui/app/unlock.js
+++ b/old-ui/app/unlock.js
@@ -99,7 +99,7 @@ UnlockScreen.prototype.onSubmit = async function (event) {
   const password = input.value
   try {
     await this.props.dispatch(actions.tryUnlockMetamask(password))
-  } catch(e) {
+  } catch (e) {
     log.error(e)
   }
 }
@@ -117,7 +117,7 @@ UnlockScreen.prototype.submitPassword = async function (event) {
   element.value = ''
   try {
     await this.props.dispatch(actions.tryUnlockMetamask(password))
-  } catch(e) {
+  } catch (e) {
     log.error(e)
   }
 }

--- a/old-ui/app/unlock.js
+++ b/old-ui/app/unlock.js
@@ -100,7 +100,7 @@ UnlockScreen.prototype.onSubmit = async function (event) {
   try {
     await this.props.dispatch(actions.tryUnlockMetamask(password))
   } catch(e) {
-    log.info(e)
+    log.error(e)
   }
 }
 
@@ -118,7 +118,7 @@ UnlockScreen.prototype.submitPassword = async function (event) {
   try {
     await this.props.dispatch(actions.tryUnlockMetamask(password))
   } catch(e) {
-    log.info(e)
+    log.error(e)
   }
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8579,9 +8579,9 @@
             }
         },
         "eth-keychain-controller": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/eth-keychain-controller/-/eth-keychain-controller-4.0.1.tgz",
-            "integrity": "sha512-4SR3+JxSrlCjyM6FfAlH73vr9zZ3n1nWuspAlF0B40fDDipjPouc+KqxKeqXHgQoAYm3Rub2OUVUfj9V0KqiBA==",
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/eth-keychain-controller/-/eth-keychain-controller-4.0.2.tgz",
+            "integrity": "sha512-1NbyfdrmniEwcXdYhVeKRbw9JkqZRRexBM2QRydf613htE0jxzmQZaTMvMKV4rNL/S3fxYPd1AbLhQ3lZRiffw==",
             "dev": true,
             "requires": {
                 "bip39": "^2.4.0",
@@ -8826,24 +8826,13 @@
             },
             "dependencies": {
                 "eth-sig-util": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/eth-sig-util/-/eth-sig-util-2.0.1.tgz",
-                    "integrity": "sha512-lxHZOQspexk3DaGj4RBbWy4C/qNOWRnxpaJzNnYD3WEmC8shcJ4tHs7Xv878rzvILfJnSFSCCiKQhng1m80oBQ==",
+                    "version": "2.0.2",
+                    "resolved": "https://registry.npmjs.org/eth-sig-util/-/eth-sig-util-2.0.2.tgz",
+                    "integrity": "sha512-tB6E8jf/aZQ943bo3+iojl8xRe3Jzcl+9OT6v8K7kWis6PdIX19SB2vYvN849cB9G9m/XLjYFK381SgdbsnpTA==",
                     "dev": true,
                     "requires": {
-                        "ethereumjs-abi": "git+https://github.com/ethereumjs/ethereumjs-abi.git#00ba8463a7f7a67fcad737ff9c2ebd95643427f7",
+                        "ethereumjs-abi": "0.6.5",
                         "ethereumjs-util": "^5.1.1"
-                    },
-                    "dependencies": {
-                        "ethereumjs-abi": {
-                            "version": "git+https://github.com/ethereumjs/ethereumjs-abi.git#00ba8463a7f7a67fcad737ff9c2ebd95643427f7",
-                            "from": "git+https://github.com/ethereumjs/ethereumjs-abi.git",
-                            "dev": true,
-                            "requires": {
-                                "bn.js": "^4.10.0",
-                                "ethereumjs-util": "^5.0.0"
-                            }
-                        }
                     }
                 },
                 "ethereumjs-util": {

--- a/package.json
+++ b/package.json
@@ -245,7 +245,7 @@
     "eslint-plugin-mocha": "^5.0.0",
     "eslint-plugin-react": "^7.4.0",
     "eth-json-rpc-middleware": "^1.6.0",
-    "eth-keychain-controller": "^4.0.1",
+    "eth-keychain-controller": "^4.0.2",
     "file-loader": "^1.1.11",
     "fs-promise": "^2.0.3",
     "ganache-cli": "^6.1.0",

--- a/ui/app/actions.js
+++ b/ui/app/actions.js
@@ -349,6 +349,10 @@ function tryUnlockMetamask (password) {
         dispatch(actions.unlockSucceeded())
         return forceUpdateMetamaskState(dispatch)
       })
+      .catch((err) => {
+        log.error(err)
+        return Promise.reject(err)
+      })
       .then(() => {
         return new Promise((resolve, reject) => {
           background.verifySeedPhrase(err => {
@@ -564,10 +568,9 @@ function changePassword (oldPassword, newPassword) {
       background.changePassword(oldPassword, newPassword, (err, account) => {
         dispatch(actions.hideLoadingIndication())
         if (err) {
-          dispatch(actions.displayWarning(err.message))
+          log.error(err)
           return reject(err)
         }
-
         log.info('Password is changed for ' + account)
         dispatch(actions.showAccountsPage())
         resolve(account)


### PR DESCRIPTION
Relates to https://github.com/poanetwork/metamask-extension/issues/86

Uncaught exceptions on login/change password in Promise is handled.
Related changes in affected `eth-keychin-controller`: https://github.com/vbaranov/KeyringController/pull/1/files

`log.error` will be instead of `Uncaught (in promise)`