### PR TITLE
(Fix) to display localhost:8545 in Settings

### DIFF
--- a/app/scripts/lib/config-manager.js
+++ b/app/scripts/lib/config-manager.js
@@ -1,13 +1,5 @@
 const ethUtil = require('ethereumjs-util')
 const normalize = require('eth-sig-util').normalize
-const {
-  MAINNET_RPC_URL,
-  ROPSTEN_RPC_URL,
-  KOVAN_RPC_URL,
-  RINKEBY_RPC_URL,
-  POA_SOKOL_RPC_URL,
-  POA_RPC_URL,
-} = require('../controllers/network/enums')
 
 /* The config-manager is a convenience object
  * wrapping a pojo-migrator.
@@ -147,34 +139,6 @@ ConfigManager.prototype.useEtherscanProvider = function () {
 ConfigManager.prototype.getProvider = function () {
   var config = this.getConfig()
   return config.provider
-}
-
-ConfigManager.prototype.getCurrentRpcAddress = function () {
-  var provider = this.getProvider()
-  if (!provider) return null
-  switch (provider.type) {
-
-    case 'mainnet':
-      return MAINNET_RPC_URL
-
-    case 'ropsten':
-      return ROPSTEN_RPC_URL
-
-    case 'kovan':
-      return KOVAN_RPC_URL
-
-    case 'rinkeby':
-      return RINKEBY_RPC_URL
-
-    case 'sokol':
-      return POA_SOKOL_RPC_URL
-
-    case 'poa':
-      return POA_RPC_URL
-
-    default:
-      return provider && provider.rpcTarget ? provider.rpcTarget : POA_SOKOL_RPC_URL
-  }
 }
 
 //

--- a/old-ui/app/app.js
+++ b/old-ui/app/app.js
@@ -719,10 +719,10 @@ App.prototype.getNetworkName = function () {
 
 App.prototype.renderCommonRpc = function (rpcList, provider) {
   const props = this.props
-  const rpcTarget = provider.rpcTarget
+  const { rpcTarget, type } = provider
 
   return rpcList.map((rpc) => {
-    if (rpc === rpcTarget) {
+    if (type === 'rpc' && rpc === rpcTarget) {
       return null
     } else {
       return h(

--- a/old-ui/app/app.js
+++ b/old-ui/app/app.js
@@ -374,7 +374,10 @@ App.prototype.renderNetworkDropdown = function () {
       {
         key: 'default',
         closeMenu: () => this.setState({ isNetworkMenuOpen: !isOpen }),
-        onClick: () => props.dispatch(actions.setProviderType('localhost')),
+        onClick: () => {
+          props.dispatch(actions.setRpcTarget('http://localhost:8545'))
+          props.dispatch(actions.setProviderType('localhost'))
+        },
         style: {
           paddingLeft: '20px',
           fontSize: '16px',
@@ -386,7 +389,7 @@ App.prototype.renderNetworkDropdown = function () {
       ]
     ),
 
-    this.renderCustomOption(props.provider),
+    this.renderSelectedCustomOption(props.provider),
     this.renderCommonRpc(rpcList, props.provider),
 
     h(
@@ -668,10 +671,9 @@ App.prototype.toggleMetamaskActive = function () {
   }
 }
 
-App.prototype.renderCustomOption = function (provider) {
+App.prototype.renderSelectedCustomOption = function (provider) {
   const { rpcTarget, type } = provider
   const props = this.props
-
   if (type !== 'rpc') return null
 
   // Concatenate long URLs
@@ -681,9 +683,6 @@ App.prototype.renderCustomOption = function (provider) {
   }
 
   switch (rpcTarget) {
-
-    case 'http://localhost:8545':
-      return null
 
     default:
       return h(
@@ -723,7 +722,7 @@ App.prototype.renderCommonRpc = function (rpcList, provider) {
   const rpcTarget = provider.rpcTarget
 
   return rpcList.map((rpc) => {
-    if ((rpc === 'http://localhost:8545') || (provider.type === 'rpc' && rpc === rpcTarget)) {
+    if (rpc === rpcTarget) {
       return null
     } else {
       return h(

--- a/old-ui/app/components/network.js
+++ b/old-ui/app/components/network.js
@@ -61,8 +61,8 @@ Network.prototype.render = function () {
       displayName = 'POA Network'
       hoverText = ethNetProps.props.getNetworkDisplayName(networkNumber)
     } else {
-      hoverText = (provider.type === 'rpc') ? `Private Network (${provider.rpcTarget})` : `Private Network (${provider.type})`
       displayName = 'Private Network'
+      hoverText = `Private Network (${provider.rpcTarget})`
     }
   }
 

--- a/test/unit/config-manager-test.js
+++ b/test/unit/config-manager-test.js
@@ -75,21 +75,6 @@ describe('config-manager', function () {
     })
   })
 
-  describe('rpc manipulations', function () {
-    it('changing rpc should return a different rpc', function () {
-      var firstRpc = 'first'
-      var secondRpc = 'second'
-
-      configManager.setRpcTarget(firstRpc)
-      var firstResult = configManager.getCurrentRpcAddress()
-      assert.equal(firstResult, firstRpc)
-
-      configManager.setRpcTarget(secondRpc)
-      var secondResult = configManager.getCurrentRpcAddress()
-      assert.equal(secondResult, secondRpc)
-    })
-  })
-
   describe('transactions', function () {
     beforeEach(function () {
       configManager.setTxList([])


### PR DESCRIPTION
Relates to https://github.com/poanetwork/metamask-extension/issues/102

- RPC target is added for `localhost:8545` option
- Unused function to get RPC addresses `getCurrentRpcAddress` is removed
- `renderCustomOption` was renamed to `renderSelectedCustomOption` to better fit the logic of function