### PR TITLE
(Fix) Firefox scrolls

### DIFF
--- a/old-ui/app/app.js
+++ b/old-ui/app/app.js
@@ -420,6 +420,7 @@ App.prototype.renderDropdown = function () {
     useCssTransition: true,
     isOpen: isOpen,
     zIndex: 11,
+    constOverflow: true,
     onClickOutside: (event) => {
       const classList = event.target.classList
       const parentClassList = event.target.parentElement.classList
@@ -440,6 +441,7 @@ App.prototype.renderDropdown = function () {
       top: '38px',
       width: '126px',
       maxHeight: isOpen ? '186px' : '0px',
+      overflow: 'hidden',
     },
     innerStyle: {},
   }, [

--- a/old-ui/app/components/dropdown.js
+++ b/old-ui/app/components/dropdown.js
@@ -8,7 +8,7 @@ const noop = () => {}
 
 class Dropdown extends Component {
   render () {
-    const { isOpen, onClickOutside, style, innerStyle, children, useCssTransition } = this.props
+    const { isOpen, onClickOutside, style, innerStyle, children, useCssTransition, constOverflow } = this.props
 
     const innerStyleDefaults = extend({
       padding: '15px 30px',
@@ -29,6 +29,7 @@ class Dropdown extends Component {
         useCssTransition,
         isOpen,
         zIndex: 11,
+        constOverflow,
         onClickOutside,
         style: styleDefaults,
         innerStyle: innerStyleDefaults,
@@ -61,6 +62,7 @@ Dropdown.propTypes = {
   onClickOutside: PropTypes.func,
   innerStyle: PropTypes.object,
   useCssTransition: PropTypes.bool,
+  constOverflow: PropTypes.bool,
 }
 
 class DropdownMenuItem extends Component {

--- a/old-ui/app/components/menu-droppo.js
+++ b/old-ui/app/components/menu-droppo.js
@@ -24,9 +24,11 @@ MenuDroppoComponent.prototype.render = function () {
     style.position = 'fixed'
   }
   style.zIndex = zIndex
+  style.overflow = 'hidden'
 
   return (
     h('.menu-droppo-container', {
+      ref: 'menuDroppoContainer',
       style,
     }, [
       useCssTransition
@@ -77,6 +79,20 @@ MenuDroppoComponent.prototype.componentDidMount = function () {
     var container = findDOMNode(this)
     this.container = container
   }
+
+  /*
+   * transitionstart event is not supported in Chrome yet. But it works for Firefox 53+.
+   * We need to handle this event only for FF because for Chrome we hidden scrolls.
+  */
+  this.refs.menuDroppoContainer.addEventListener('transitionstart', () => {
+    this.refs.menuDroppoContainer.style.overflow = 'hidden'
+  })
+
+  this.refs.menuDroppoContainer.addEventListener('transitionend', () => {
+    if (!this.props.constOverflow) {
+      this.refs.menuDroppoContainer.style.overflow = 'auto'
+    }
+  })
 }
 
 MenuDroppoComponent.prototype.componentWillUnmount = function () {

--- a/old-ui/app/css/index.css
+++ b/old-ui/app/css/index.css
@@ -1009,11 +1009,11 @@ div.message-container > div:first-child {
 }
 
 .menu-droppo-container::-webkit-scrollbar {
-  width: 1px;
+  width: 0px;
 }
  
 .menu-droppo-container::-webkit-scrollbar-thumb {
-  border: 1px solid transparent;
+  border: none;
   background-clip: content-box;
 }
 


### PR DESCRIPTION
Relates to https://github.com/poanetwork/metamask-extension/issues/111

- Fixes FF scroll for the main menu
- Disables FF scrolls on animation
- Sets constant zero width for dropdown in Chrome 