### PR TITLE
(Fix) remove test domains form ENS resolver

### DIFF
--- a/app/manifest.json
+++ b/app/manifest.json
@@ -63,7 +63,6 @@
     "activeTab",
     "webRequest",
     "*://*.eth/",
-    "*://*.test/",
     "notifications"
   ],
   "web_accessible_resources": [

--- a/app/scripts/lib/ipfsContent.js
+++ b/app/scripts/lib/ipfsContent.js
@@ -34,7 +34,7 @@ module.exports = function (provider) {
       return { cancel: true }
     }
 
-    extension.webRequest.onBeforeRequest.addListener(ipfsContent, {urls: ['*://*.eth/', '*://*.test/']})
+    extension.webRequest.onBeforeRequest.addListener(ipfsContent, {urls: ['*://*.eth/']})
 
     return {
       remove () {


### PR DESCRIPTION
Relates to https://github.com/poanetwork/metamask-extension/issues/106

How to test: typing `test` in the address bar should not lead to this page:
![2018-09-11 17 13 28](https://user-images.githubusercontent.com/4341812/45365810-08d3bd80-b5e6-11e8-89f0-3b66a61cc50c.png)
