### PR TITLE
e2e search tokens

### DIFF
--- a/test/e2e/elements.js
+++ b/test/e2e/elements.js
@@ -86,8 +86,6 @@ module.exports = {
             name: By.className('confirm-add-token__name'),
             icon: By.className('confirm-add-token__token-icon identicon'),
           },
-
-
         },
       },
       custom:

--- a/test/e2e/elements.js
+++ b/test/e2e/elements.js
@@ -56,12 +56,30 @@ module.exports = {
     addToken: {
       title: By.className('page-subtitle'),
       titleText: 'Add Token',
-      fields: {
-        contractAddress: By.id('token-address'),
-        tokenSymbol: By.id('token_symbol'),
-        decimals: By.id('token_decimals'),
+      tab:{
+        custom:By.className('inactiveForm pointer'),
+        search:By.className('inactiveForm pointer')
+       },
+      search: {
+        fieldSearch: By.id('search-tokens'),
+        results: By.className('token-list__token-data'),
+        buttons: {
+          next: By.css('#app-content > div > div.app-primary.from-right > div > div:nth-child(3) > div.page-container__footer > div > button:nth-child(2)'),
+          cancel: By.className('btn-violet')
+        }
       },
-      buttonAdd: By.css('.flex-space-around > button:nth-child(7)'),
+      custom:
+        {
+          fields: {
+            contractAddress: By.id('token-address'),
+            tokenSymbol: By.id('token_symbol'),
+            decimals: By.id('token_decimals'),
+          },
+          buttons: {
+            add: By.css('#app-content > div > div.app-primary.from-right > div > div.flex-column.flex-justify-center.flex-grow.select-none > div > div:nth-child(7) > button:nth-child(2)'),
+            cancel: By.className('btn-violet')
+          },
+        },
 
     },
     deleteCustomRPC: {

--- a/test/e2e/elements.js
+++ b/test/e2e/elements.js
@@ -56,17 +56,17 @@ module.exports = {
     addToken: {
       title: By.className('page-subtitle'),
       titleText: 'Add Token',
-      tab:{
-        custom:By.className('inactiveForm pointer'),
-        search:By.className('inactiveForm pointer')
+      tab: {
+        custom: By.className('inactiveForm pointer'),
+        search: By.className('inactiveForm pointer'),
        },
       search: {
         fieldSearch: By.id('search-tokens'),
         results: By.className('token-list__token-data'),
         buttons: {
           next: By.css('#app-content > div > div.app-primary.from-right > div > div:nth-child(3) > div.page-container__footer > div > button:nth-child(2)'),
-          cancel: By.className('btn-violet')
-        }
+          cancel: By.className('btn-violet'),
+        },
       },
       custom:
         {
@@ -77,7 +77,7 @@ module.exports = {
           },
           buttons: {
             add: By.css('#app-content > div > div.app-primary.from-right > div > div.flex-column.flex-justify-center.flex-grow.select-none > div > div:nth-child(7) > button:nth-child(2)'),
-            cancel: By.className('btn-violet')
+            cancel: By.className('btn-violet'),
           },
         },
 

--- a/test/e2e/elements.js
+++ b/test/e2e/elements.js
@@ -59,13 +59,35 @@ module.exports = {
       tab: {
         custom: By.className('inactiveForm pointer'),
         search: By.className('inactiveForm pointer'),
-       },
+      },
       search: {
         fieldSearch: By.id('search-tokens'),
         results: By.className('token-list__token-data'),
-        buttons: {
+        token: {
+          unselected: By.className('token-list__token'),
+          selected: By.className('token-list__token token-list__token--selected'),
+          name: By.className('token-list__token-name'),
+          icon: By.className('token-list__token-icon'),
+        },
+        button: {
           next: By.css('#app-content > div > div.app-primary.from-right > div > div:nth-child(3) > div.page-container__footer > div > button:nth-child(2)'),
           cancel: By.className('btn-violet'),
+        },
+        confirm: {
+          label: By.className('confirm-label'),
+          labelText: By.className('Would you like to add these tokens?'),
+          button: {
+            add: By.className('btn-primary'),
+            cancel: By.className('btn-default btn-violet'),
+          },
+          token: {
+            item: By.className('confirm-add-token__token-list-item'),
+            balance: By.className('confirm-add-token__balance'),
+            name: By.className('confirm-add-token__name'),
+            icon: By.className('confirm-add-token__token-icon identicon'),
+          },
+
+
         },
       },
       custom:
@@ -148,6 +170,7 @@ module.exports = {
       },
     },
     main: {
+      identicon: By.className('identicon-wrapper select-none'),
       accountName: By.className('sizing-input'),
       edit: By.className('edit-text'),
       iconCopy: By.className('clipboard cursor-pointer white'),
@@ -168,13 +191,14 @@ module.exports = {
       tokens: {
         remove: By.className('trash'),
         menu: By.className('inactiveForm pointer'),
-        token: By.css('#app-content > div > div.app-primary.from-left > div > section > div.full-flex-height > ol > li'),
+        token: By.className('token-cell'),
         balance: By.css('#app-content > div > div.app-primary.from-left > div > section > div.full-flex-height > ol > li:nth-child(2) > h3'),
         amount: By.css('#app-content > div > div.app-primary.from-left > div > section > div.full-flex-height > div > span'),
         textNoTokens: 'No tokens found',
         textYouOwn1token: 'You own 1 token',
         buttonAdd: By.css('div.full-flex-height:nth-child(2) > div:nth-child(1) > button:nth-child(2)'),
         buttonAddText: 'Add Token',
+        counter: By.css('#app-content > div > div.app-primary.from-left > div > section > div.full-flex-height > div > span'),
       },
     },
     info: {

--- a/test/e2e/metamask.spec.js
+++ b/test/e2e/metamask.spec.js
@@ -50,7 +50,7 @@ describe('Metamask popup page', async function () {
   })
 
   after(async function () {
-    // await driver.quit()
+    await driver.quit()
   })
 
   describe('Setup', async function () {

--- a/test/e2e/metamask.spec.js
+++ b/test/e2e/metamask.spec.js
@@ -937,7 +937,7 @@ describe('Metamask popup page', async function () {
 
       it('adds token parameters', async function () {
         const tab = await waitUntilShowUp(screens.addToken.tab.custom)
-        await tab.click()
+        if (! await waitUntilShowUp(screens.addToken.custom.fields.contractAddress)) await tab.click()
         const tokenContractAddress = await waitUntilShowUp(screens.addToken.custom.fields.contractAddress)
         await tokenContractAddress.sendKeys(tokenAddress)
         const button = await waitUntilShowUp(screens.addToken.custom.buttons.add)

--- a/test/e2e/metamask.spec.js
+++ b/test/e2e/metamask.spec.js
@@ -231,7 +231,7 @@ describe('Metamask popup page', async function () {
     })
 
   })
-  describe.skip('Export private key', async () => {
+  describe('Export private key', async () => {
 
     it('open dialog', async function () {
       await driver.navigate().refresh()
@@ -304,7 +304,7 @@ describe('Metamask popup page', async function () {
     })
   })
 
-  describe.skip('Change password', async () => {
+  describe('Change password', async () => {
     const newPassword = {
       correct: 'abcDEF123!@#',
       short: '123',
@@ -315,7 +315,7 @@ describe('Metamask popup page', async function () {
     let fieldOldPassword
     let buttonYes
 
-    describe.skip('Check screen "Settings" -> "Change password" ', async () => {
+    describe('Check screen "Settings" -> "Change password" ', async () => {
 
       it('checks if current network name (localhost) is correct', async () => {
         const menu = await waitUntilShowUp(menus.sandwich.menu, 300)
@@ -478,7 +478,7 @@ describe('Metamask popup page', async function () {
     })
   })
 
-  describe.skip('Import Account', () => {
+  describe('Import Account', () => {
 
     it('opens import account menu', async function () {
       const menu = await waitUntilShowUp(menus.account.menu)
@@ -571,7 +571,7 @@ describe('Metamask popup page', async function () {
       await click(field)
     })
 
-    it.skip('balance renders', async function () {
+    it('balance renders', async function () {
       const balance = await waitUntilShowUp(screens.main.balance)
       assert.equal(await balance.getText(), '100.000')
     })

--- a/test/e2e/metamask.spec.js
+++ b/test/e2e/metamask.spec.js
@@ -50,7 +50,7 @@ describe('Metamask popup page', async function () {
   })
 
   after(async function () {
-    await driver.quit()
+    //await driver.quit()
   })
 
   describe('Setup', async function () {
@@ -231,7 +231,7 @@ describe('Metamask popup page', async function () {
     })
 
   })
-  describe('Export private key', async () => {
+  describe.skip('Export private key', async () => {
 
     it('open dialog', async function () {
       await driver.navigate().refresh()
@@ -304,7 +304,7 @@ describe('Metamask popup page', async function () {
     })
   })
 
-  describe('Change password', async () => {
+  describe.skip('Change password', async () => {
     const newPassword = {
       correct: 'abcDEF123!@#',
       short: '123',
@@ -315,7 +315,7 @@ describe('Metamask popup page', async function () {
     let fieldOldPassword
     let buttonYes
 
-    describe('Check screen "Settings" -> "Change password" ', async () => {
+    describe.skip('Check screen "Settings" -> "Change password" ', async () => {
 
       it('checks if current network name (localhost) is correct', async () => {
         const menu = await waitUntilShowUp(menus.sandwich.menu, 300)
@@ -478,7 +478,7 @@ describe('Metamask popup page', async function () {
     })
   })
 
-  describe('Import Account', () => {
+  describe.skip('Import Account', () => {
 
     it('opens import account menu', async function () {
       const menu = await waitUntilShowUp(menus.account.menu)
@@ -571,7 +571,7 @@ describe('Metamask popup page', async function () {
       await click(field)
     })
 
-    it('balance renders', async function () {
+    it.skip('balance renders', async function () {
       const balance = await waitUntilShowUp(screens.main.balance)
       assert.equal(await balance.getText(), '100.000')
     })
@@ -674,14 +674,18 @@ describe('Metamask popup page', async function () {
     })
 
     it('checks add token screen has correct title', async function () {
-      const addTokenScreen = await waitUntilShowUp(By.className('page-subtitle'))
+      const addTokenScreen = await waitUntilShowUp(screens.addToken.title)
       assert.equal(await addTokenScreen.getText(), screens.addToken.titleText)
     })
 
     it('adds token parameters', async function () {
-      const tokenContractAddress = await waitUntilShowUp(screens.addToken.fields.contractAddress)
+      const tab = await waitUntilShowUp(screens.addToken.tab.custom)
+      await tab.click()
+      console.log(1)
+      const tokenContractAddress = await waitUntilShowUp(screens.addToken.custom.fields.contractAddress)
       await tokenContractAddress.sendKeys(tokenAddress)
-      const button = await waitUntilShowUp(screens.addToken.buttonAdd)
+      console.log(2)
+      const button = await waitUntilShowUp(screens.addToken.custom.buttons.add)
       await click(button)
     })
 
@@ -1079,7 +1083,7 @@ describe('Metamask popup page', async function () {
   }
 
   async function waitUntilShowUp (by, Twait) {
-    if (Twait === undefined) Twait = 2000
+    if (Twait === undefined) Twait = 20
     do {
       await delay(100)
       if (await isElementDisplayed(by)) return await driver.findElement(by)
@@ -1117,11 +1121,17 @@ describe('Metamask popup page', async function () {
     try {
       const button = await waitUntilShowUp(screens.main.tokens.buttonAdd, 300)
       await click(button)
-      const field = await waitUntilShowUp(screens.addToken.fields.contractAddress)
+      //await delay(2000)
+      do {
+        const tab = await waitUntilShowUp(screens.addToken.tab.custom)
+        await tab.click()
+      }
+      while( await waitUntilShowUp(screens.addToken.custom.fields.contractAddress) === false)
+      const field = await waitUntilShowUp(screens.addToken.custom.fields.contractAddress)
       await clearField(field)
       await field.sendKeys(tokenAddress)
 
-      const buttonAdd = await waitUntilShowUp(screens.addToken.buttonAdd)
+      const buttonAdd = await waitUntilShowUp(screens.addToken.custom.buttons.add)
       await click(buttonAdd)
       return true
     } catch (err) {

--- a/test/e2e/metamask.spec.js
+++ b/test/e2e/metamask.spec.js
@@ -619,8 +619,9 @@ describe('Metamask popup page', async function () {
 
     describe('add Mainnet\'s tokens', function () {
 
-      it('user is able to open Add tokens:Search, field \'Search\' is displayed', async function () {
+      it(' field \'Search\' is displayed', async function () {
         await setProvider(NETWORKS.MAINNET)
+        await delay(2000)
         const tab = await waitUntilShowUp(screens.main.tokens.menu)
         await tab.click()
         const button = await waitUntilShowUp(screens.main.tokens.buttonAdd, 300)
@@ -792,7 +793,7 @@ describe('Metamask popup page', async function () {
       })
 
     })
-    describe.skip('Token should be displayed only for network, where it was added ', async function () {
+    describe('Token should be displayed only for network, where it was added ', async function () {
 
       it('token should not  be displayed in POA network', async function () {
         await setProvider(NETWORKS.POA)
@@ -804,7 +805,8 @@ describe('Metamask popup page', async function () {
         assert.equal(await assertTokensNotDisplayed(), true, 'tokens are displayed')
       })
 
-      it('token should not  be displayed in LOCALHOST network', async function () {
+      it.skip('token should not  be displayed in LOCALHOST network', async function () {
+        console.log('https://github.com/poanetwork/metamask-extension/issues/131')
         await setProvider(NETWORKS.LOCALHOST)
         assert.equal(await assertTokensNotDisplayed(), true, 'tokens are displayed')
       })
@@ -937,7 +939,7 @@ describe('Metamask popup page', async function () {
 
       it('adds token parameters', async function () {
         const tab = await waitUntilShowUp(screens.addToken.tab.custom)
-        if (! await waitUntilShowUp(screens.addToken.custom.fields.contractAddress)) await tab.click()
+        if (!await waitUntilShowUp(screens.addToken.custom.fields.contractAddress)) await tab.click()
         const tokenContractAddress = await waitUntilShowUp(screens.addToken.custom.fields.contractAddress)
         await tokenContractAddress.sendKeys(tokenAddress)
         const button = await waitUntilShowUp(screens.addToken.custom.buttons.add)
@@ -1379,13 +1381,12 @@ describe('Metamask popup page', async function () {
     try {
       const button = await waitUntilShowUp(screens.main.tokens.buttonAdd, 300)
       await click(button)
-      // await delay(2000)
+
       do {
-        const tab = await waitUntilShowUp(screens.addToken.tab.custom)
+        const tab = await waitUntilShowUp(screens.addToken.tab.custom, 10)
         try {
           await tab.click()
         } catch (err) {
-          console.log(err)
         }
 
       }

--- a/test/e2e/metamask.spec.js
+++ b/test/e2e/metamask.spec.js
@@ -50,7 +50,7 @@ describe('Metamask popup page', async function () {
   })
 
   after(async function () {
-    //await driver.quit()
+    await driver.quit()
   })
 
   describe('Setup', async function () {
@@ -1083,7 +1083,7 @@ describe('Metamask popup page', async function () {
   }
 
   async function waitUntilShowUp (by, Twait) {
-    if (Twait === undefined) Twait = 20
+    if (Twait === undefined) Twait = 200
     do {
       await delay(100)
       if (await isElementDisplayed(by)) return await driver.findElement(by)
@@ -1121,12 +1121,12 @@ describe('Metamask popup page', async function () {
     try {
       const button = await waitUntilShowUp(screens.main.tokens.buttonAdd, 300)
       await click(button)
-      //await delay(2000)
+      // await delay(2000)
       do {
         const tab = await waitUntilShowUp(screens.addToken.tab.custom)
         await tab.click()
       }
-      while( await waitUntilShowUp(screens.addToken.custom.fields.contractAddress) === false)
+      while (await waitUntilShowUp(screens.addToken.custom.fields.contractAddress) === false)
       const field = await waitUntilShowUp(screens.addToken.custom.fields.contractAddress)
       await clearField(field)
       await field.sendKeys(tokenAddress)


### PR DESCRIPTION
Relates to https://github.com/poanetwork/metamask-extension/pull/135

Added e2e tests for `Add token: search` feature:
```
      add Mainnet's tokens
        ✓ field 'Search' is displayed (3054ms)
        ✓ button 'Next' is disabled if no tokens found (171ms)
        ✓ button 'Cancel' is enabled and lead to main screen  (187ms)
        ✓ Search by name: searching result list is empty if request invalid (2601ms)
        ✓ Search by name: searching result list isn't empty  (1177ms)
        ✓ Token's info contains name, symbol and picture 
        ✓ button 'Next' is disabled if no one token is selected (131ms)
        ✓ user can select one token (180ms)
        ✓ button 'Next' is enabled if token is selected (137ms)
        ✓ user can unselected token (165ms)
        ✓ button 'Next' is disabled after token was unselected (132ms)
        ✓ user can select two tokens (247ms)
        ✓ click button 'Next' opens confirm screen  (360ms)
        ✓ two selected tokens displayed and have correct parameters (2139ms)
        ✓ button 'Cancel' is enabled and leads to main screen  (353ms)
        ✓ button 'Next' is enabled if confirmation list isn't empty (467ms)
        ✓ Search by contract address: searching result list is empty if address invalid  (2876ms)
        ✓ Search by valid contract address: searching result list contains one token  (2527ms)
        ✓ Token's info contains correct name  (159ms)
        ✓ one more token added to confirmation list (334ms)
        ✓ button 'Add tokens' is enabled and clickable (326ms)
        ✓ all selected tokens are displayed on main screen (153ms)
        ✓ correct value of counter of owned tokens (162ms)
      Token should be displayed only for network, where it was added 
        ✓ token should not  be displayed in POA network (1641ms)
        ✓ token should not  be displayed in SOKOL network (1612ms)
        - token should not  be displayed in LOCALHOST network
        ✓ token should not  be displayed in ROPSTEN network (1589ms)
        ✓ token should not  be displayed in KOVAN network (1601ms)
        ✓ token should not  be displayed in RINKEBY network (1574ms)
      remove Mainnet's tokens
        ✓ remove tokens (3428ms)
```