### PR TITLE
e2e token menu

### DIFF
--- a/test/e2e/elements.js
+++ b/test/e2e/elements.js
@@ -5,6 +5,16 @@ module.exports = {
     loader: By.css('#app-content > div > div.full-flex-height > img'),
   },
   menus: {
+    token: {
+      menu: By.id('token-cell_dropdown_0'),
+      items: By.className('dropdown-menu-item'),
+      view: By.css('#token-cell_dropdown_0 > div > div > li:nth-child(2)'),
+      copy: By.css('#token-cell_dropdown_0 > div > div > li:nth-child(3)'),
+      remove: By.css('#token-cell_dropdown_0 > div > div > li:nth-child(4)'),
+      viewText: 'View token on block explorer',
+      copyText: 'Copy address to clipboard',
+      removeText: 'Remove',
+    },
     sandwich: {
       menu: By.css('.sandwich-expando'),
       settings: By.css('#app-content > div > div:nth-child(3) > span > div > li:nth-child(2)'),
@@ -148,7 +158,6 @@ module.exports = {
       balance: By.css('#app-content > div > div.app-primary.from-right > div > div > div.flex-row > div.ether-balance.ether-balance-amount > div > div > div:nth-child(1) > div:nth-child(1)'),
       address: By.css('#app-content > div > div.app-primary.from-left > div > div > div:nth-child(1) > flex-column > div.flex-row > div'),
       tokens: {
-        remove: By.className('trash'),
         menu: By.className('inactiveForm pointer'),
         token: By.css('#app-content > div > div.app-primary.from-left > div > section > div.full-flex-height > ol > li'),
         balance: By.css('#app-content > div > div.app-primary.from-left > div > section > div.full-flex-height > ol > li:nth-child(2) > h3'),
@@ -169,7 +178,7 @@ module.exports = {
       title: By.className('page-subtitle'),
       titleText: 'Remove Token',
       label: By.className('confirm-label'),
-      labelText: 'Are you sure you want to remove token',
+      labelText: 'Are you sure you want to remove token "TST"?',
       buttons: {
         back: By.className('fa fa-arrow-left fa-lg cursor-pointer'),
         no: By.className('btn-violet'),

--- a/test/e2e/metamask.spec.js
+++ b/test/e2e/metamask.spec.js
@@ -747,7 +747,7 @@ describe('Nifty wallet popup page', async function () {
         assert.notEqual(await tokenBalance.getText(), '')
       })
 
-      it('click to token opens the PoaExplorer', async function () {
+      it.skip('click to token opens the PoaExplorer', async function () {
         await (await waitUntilShowUp(screens.main.tokens.token)).click()
         await switchToLastPage()
         const title = await driver.getCurrentUrl()

--- a/test/e2e/metamask.spec.js
+++ b/test/e2e/metamask.spec.js
@@ -50,7 +50,7 @@ describe('Nifty wallet popup page', async function () {
   })
 
   after(async function () {
-    // await driver.quit()
+     await driver.quit()
   })
 
   describe('Setup', async function () {
@@ -698,14 +698,6 @@ describe('Nifty wallet popup page', async function () {
       const tokenBalance = await waitUntilShowUp(screens.main.tokens.balance)
       assert.equal(await tokenBalance.getText(), '0 TST')
     })
-
-    it('click to token opens the etherscan', async function () {
-      await (await waitUntilShowUp(screens.main.tokens.token)).click()
-      await switchToLastPage()
-      const title = await driver.getCurrentUrl()
-      assert.equal(title.includes('https://etherscan.io/token/'), true, 'link leads to wrong page')
-      await switchToFirstPage()
-    })
   })
 
   describe('Check support of token per network basis ', async function () {
@@ -755,11 +747,27 @@ describe('Nifty wallet popup page', async function () {
         assert.notEqual(await tokenBalance.getText(), '')
       })
 
+      it('click to token opens the PoaExplorer', async function () {
+        await (await waitUntilShowUp(screens.main.tokens.token)).click()
+        await switchToLastPage()
+        const title = await driver.getCurrentUrl()
+        assert.equal(title.includes('https://poaexplorer.com/address/' + tokenAddress), true, 'link leads to wrong page')
+        await switchToFirstPage()
+      })
+
       it('adds token with  the same address to SOKOL network', async function () {
         await setProvider(NETWORKS.SOKOL)
         await addToken(tokenAddress, tokenName, tokenDecimals)
         const tokenBalance = await waitUntilShowUp(screens.main.tokens.balance)
         assert.notEqual(await tokenBalance.getText(), '')
+      })
+
+      it('click to token opens the Sokol PoaExplorer', async function () {
+        await (await waitUntilShowUp(screens.main.tokens.token)).click()
+        await switchToLastPage()
+        const title = await driver.getCurrentUrl()
+        assert.equal(title.includes('https://sokol.poaexplorer.com/address/search/' + tokenAddress), true, 'link leads to wrong page')
+        await switchToFirstPage()
       })
 
       it('adds token with  the same address to MAINNET network', async function () {
@@ -769,11 +777,27 @@ describe('Nifty wallet popup page', async function () {
         assert.notEqual(await tokenBalance.getText(), '')
       })
 
+      it('click to token opens the Etherscan', async function () {
+        await (await waitUntilShowUp(screens.main.tokens.token)).click()
+        await switchToLastPage()
+        const title = await driver.getCurrentUrl()
+        assert.equal(title.includes('https://etherscan.io/token/' + tokenAddress), true, 'link leads to wrong page')
+        await switchToFirstPage()
+      })
+
       it('adds token with  the same address to ROPSTEN network', async function () {
         await setProvider(NETWORKS.ROPSTEN)
         await addToken(tokenAddress, tokenName, tokenDecimals)
         const tokenBalance = await waitUntilShowUp(screens.main.tokens.balance)
         assert.notEqual(await tokenBalance.getText(), '')
+      })
+
+      it('click to token opens the Ropsten Etherscan', async function () {
+        await (await waitUntilShowUp(screens.main.tokens.token)).click()
+        await switchToLastPage()
+        const title = await driver.getCurrentUrl()
+        assert.equal(title.includes('https://ropsten.etherscan.io/token/' + tokenAddress), true, 'link leads to wrong page')
+        await switchToFirstPage()
       })
 
       it('adds token with  the same address to KOVAN network', async function () {
@@ -783,11 +807,27 @@ describe('Nifty wallet popup page', async function () {
         assert.notEqual(await tokenBalance.getText(), '')
       })
 
+      it('click to token opens the Kovan Etherscan', async function () {
+        await (await waitUntilShowUp(screens.main.tokens.token)).click()
+        await switchToLastPage()
+        const title = await driver.getCurrentUrl()
+        assert.equal(title.includes('https://kovan.etherscan.io/token/' + tokenAddress), true, 'link leads to wrong page')
+        await switchToFirstPage()
+      })
+
       it('adds token with  the same address to RINKEBY network', async function () {
         await setProvider(NETWORKS.RINKEBY)
         await addToken(tokenAddress, tokenName, tokenDecimals)
         const tokenBalance = await waitUntilShowUp(screens.main.tokens.balance)
         assert.notEqual(await tokenBalance.getText(), '')
+      })
+
+      it('click to token opens the Rinkeby Etherscan', async function () {
+        await (await waitUntilShowUp(screens.main.tokens.token)).click()
+        await switchToLastPage()
+        const title = await driver.getCurrentUrl()
+        assert.equal(title.includes('https://rinkeby.etherscan.io/token/' + tokenAddress), true, 'link leads to wrong page')
+        await switchToFirstPage()
       })
 
       it('token still should be displayed in LOCALHOST network', async function () {
@@ -797,6 +837,14 @@ describe('Nifty wallet popup page', async function () {
         const tokens = await driver.findElements(screens.main.tokens.amount)
         assert.equal(tokens.length, 1, '\'Tokens\' section doesn\'t contain field with amount of tokens')
         assert.equal(await tokens[0].getText(), screens.main.tokens.textYouOwn1token, 'Token isn\'t displayed')
+      })
+
+      it('click to token opens the Etherscan', async function () {
+        await (await waitUntilShowUp(screens.main.tokens.token)).click()
+        await switchToLastPage()
+        const title = await driver.getCurrentUrl()
+        assert.equal(title.includes('https://etherscan.io/token/' + tokenAddress), true, 'link leads to wrong page')
+        await switchToFirstPage()
       })
     })
   })
@@ -1225,7 +1273,7 @@ describe('Nifty wallet popup page', async function () {
       let counter = 100
       do {
         await delay(500)
-        if (await driver.getCurrentUrl() !== '') return true
+        if (await driver.getCurrentUrl() !== 'about:blank') return true
       }
       while (counter-- > 0)
       return true
@@ -1241,7 +1289,7 @@ describe('Nifty wallet popup page', async function () {
       let counter = 100
       do {
         await delay(500)
-        if (await driver.getCurrentUrl() !== '') return true
+        if (await driver.getCurrentUrl() !== 'about:blank') return true
       }
       while (counter-- > 0)
       return true

--- a/test/e2e/metamask.spec.js
+++ b/test/e2e/metamask.spec.js
@@ -50,7 +50,7 @@ describe('Nifty wallet popup page', async function () {
   })
 
   after(async function () {
-     await driver.quit()
+      await driver.quit()
   })
 
   describe('Setup', async function () {
@@ -698,6 +698,14 @@ describe('Nifty wallet popup page', async function () {
       const tokenBalance = await waitUntilShowUp(screens.main.tokens.balance)
       assert.equal(await tokenBalance.getText(), '0 TST')
     })
+
+    it('click to token opens the etherscan', async function () {
+      await (await waitUntilShowUp(screens.main.tokens.token)).click()
+      await switchToLastPage()
+      const title = await driver.getCurrentUrl()
+      assert.equal(title.includes('https://etherscan.io/token/'), true, 'link leads to wrong page')
+      await switchToFirstPage()
+    })
   })
 
   describe('Check support of token per network basis ', async function () {
@@ -747,27 +755,11 @@ describe('Nifty wallet popup page', async function () {
         assert.notEqual(await tokenBalance.getText(), '')
       })
 
-      it.skip('click to token opens the PoaExplorer', async function () {
-        await (await waitUntilShowUp(screens.main.tokens.token)).click()
-        await switchToLastPage()
-        const title = await driver.getCurrentUrl()
-        assert.equal(title.includes('https://poaexplorer.com/address/' + tokenAddress), true, 'link leads to wrong page')
-        await switchToFirstPage()
-      })
-
       it('adds token with  the same address to SOKOL network', async function () {
         await setProvider(NETWORKS.SOKOL)
         await addToken(tokenAddress, tokenName, tokenDecimals)
         const tokenBalance = await waitUntilShowUp(screens.main.tokens.balance)
         assert.notEqual(await tokenBalance.getText(), '')
-      })
-
-      it('click to token opens the Sokol PoaExplorer', async function () {
-        await (await waitUntilShowUp(screens.main.tokens.token)).click()
-        await switchToLastPage()
-        const title = await driver.getCurrentUrl()
-        assert.equal(title.includes('https://sokol.poaexplorer.com/address/search/' + tokenAddress), true, 'link leads to wrong page')
-        await switchToFirstPage()
       })
 
       it('adds token with  the same address to MAINNET network', async function () {
@@ -777,27 +769,11 @@ describe('Nifty wallet popup page', async function () {
         assert.notEqual(await tokenBalance.getText(), '')
       })
 
-      it('click to token opens the Etherscan', async function () {
-        await (await waitUntilShowUp(screens.main.tokens.token)).click()
-        await switchToLastPage()
-        const title = await driver.getCurrentUrl()
-        assert.equal(title.includes('https://etherscan.io/token/' + tokenAddress), true, 'link leads to wrong page')
-        await switchToFirstPage()
-      })
-
       it('adds token with  the same address to ROPSTEN network', async function () {
         await setProvider(NETWORKS.ROPSTEN)
         await addToken(tokenAddress, tokenName, tokenDecimals)
         const tokenBalance = await waitUntilShowUp(screens.main.tokens.balance)
         assert.notEqual(await tokenBalance.getText(), '')
-      })
-
-      it('click to token opens the Ropsten Etherscan', async function () {
-        await (await waitUntilShowUp(screens.main.tokens.token)).click()
-        await switchToLastPage()
-        const title = await driver.getCurrentUrl()
-        assert.equal(title.includes('https://ropsten.etherscan.io/token/' + tokenAddress), true, 'link leads to wrong page')
-        await switchToFirstPage()
       })
 
       it('adds token with  the same address to KOVAN network', async function () {
@@ -807,27 +783,11 @@ describe('Nifty wallet popup page', async function () {
         assert.notEqual(await tokenBalance.getText(), '')
       })
 
-      it('click to token opens the Kovan Etherscan', async function () {
-        await (await waitUntilShowUp(screens.main.tokens.token)).click()
-        await switchToLastPage()
-        const title = await driver.getCurrentUrl()
-        assert.equal(title.includes('https://kovan.etherscan.io/token/' + tokenAddress), true, 'link leads to wrong page')
-        await switchToFirstPage()
-      })
-
       it('adds token with  the same address to RINKEBY network', async function () {
         await setProvider(NETWORKS.RINKEBY)
         await addToken(tokenAddress, tokenName, tokenDecimals)
         const tokenBalance = await waitUntilShowUp(screens.main.tokens.balance)
         assert.notEqual(await tokenBalance.getText(), '')
-      })
-
-      it('click to token opens the Rinkeby Etherscan', async function () {
-        await (await waitUntilShowUp(screens.main.tokens.token)).click()
-        await switchToLastPage()
-        const title = await driver.getCurrentUrl()
-        assert.equal(title.includes('https://rinkeby.etherscan.io/token/' + tokenAddress), true, 'link leads to wrong page')
-        await switchToFirstPage()
       })
 
       it('token still should be displayed in LOCALHOST network', async function () {
@@ -837,14 +797,6 @@ describe('Nifty wallet popup page', async function () {
         const tokens = await driver.findElements(screens.main.tokens.amount)
         assert.equal(tokens.length, 1, '\'Tokens\' section doesn\'t contain field with amount of tokens')
         assert.equal(await tokens[0].getText(), screens.main.tokens.textYouOwn1token, 'Token isn\'t displayed')
-      })
-
-      it('click to token opens the Etherscan', async function () {
-        await (await waitUntilShowUp(screens.main.tokens.token)).click()
-        await switchToLastPage()
-        const title = await driver.getCurrentUrl()
-        assert.equal(title.includes('https://etherscan.io/token/' + tokenAddress), true, 'link leads to wrong page')
-        await switchToFirstPage()
       })
     })
   })
@@ -1273,7 +1225,7 @@ describe('Nifty wallet popup page', async function () {
       let counter = 100
       do {
         await delay(500)
-        if (await driver.getCurrentUrl() !== 'about:blank') return true
+        if (await driver.getCurrentUrl() !== '') return true
       }
       while (counter-- > 0)
       return true
@@ -1289,7 +1241,7 @@ describe('Nifty wallet popup page', async function () {
       let counter = 100
       do {
         await delay(500)
-        if (await driver.getCurrentUrl() !== 'about:blank') return true
+        if (await driver.getCurrentUrl() !== '') return true
       }
       while (counter-- > 0)
       return true


### PR DESCRIPTION
Relates token menu feature https://github.com/poanetwork/metamask-extension/pull/142 
e2e tests updated and added :
  Token menu
      ✓ token menu is displayed and clickable  (200ms)
      ✓ link 'View on blockexplorer...' leads to correct page  (2379ms)
      ✓ item 'Copy' is displayed and clickable  (506ms)
      ✓ item 'Remove' is displayed (313ms)
Also added  tests for links to block explorers
