### PR TITLE
E2e token send

### DIFF
--- a/old-ui/app/send-token.js
+++ b/old-ui/app/send-token.js
@@ -321,7 +321,7 @@ SendTransactionScreen.prototype.onSubmit = async function () {
   const recipient = state.recipient || document.querySelector('input[name="address"]').value.replace(/^[.\s]+|[.\s]+$/g, '')
   const nickname = state.nickname || ' '
   const input = document.querySelector('input[name="amount"]').value
-  const parts = input.split('')
+  const parts = input.split('.')
 
   let message
 

--- a/old-ui/app/send-token.js
+++ b/old-ui/app/send-token.js
@@ -326,14 +326,14 @@ SendTransactionScreen.prototype.onSubmit = async function () {
   let message
 
   if (isNaN(input) || input === '') {
-    message = 'Invalid tokens\' amount.'
+    message = 'Invalid token\'s amount.'
     return this.props.dispatch(actions.displayWarning(message))
   }
 
   if (parts[1]) {
     var decimal = parts[1]
     if (decimal.length > 18) {
-      message = 'Tokens\' amount is too precise.'
+      message = 'Token\'s amount is too precise.'
       return this.props.dispatch(actions.displayWarning(message))
     }
   }
@@ -343,7 +343,7 @@ SendTransactionScreen.prototype.onSubmit = async function () {
   const tokensValueWithDec = new BigNumber(calcTokenAmountWithDec(input, token.decimals))
 
   if (tokensValueWithDec.gt(token.balance)) {
-    message = 'Insufficient tokens\' balance.'
+    message = 'Insufficient token\'s balance.'
     return this.props.dispatch(actions.displayWarning(message))
   }
 

--- a/test/e2e/elements.js
+++ b/test/e2e/elements.js
@@ -8,14 +8,14 @@ module.exports = {
     token: {
       menu: By.id('token-cell_dropdown_0'),
       items: By.className('dropdown-menu-item'),
-      send:By.css('#token-cell_dropdown_0 > div > div > li:nth-child(2)'),
+      send: By.css('#token-cell_dropdown_0 > div > div > li:nth-child(2)'),
       view: By.css('#token-cell_dropdown_0 > div > div > li:nth-child(3)'),
       copy: By.css('#token-cell_dropdown_0 > div > div > li:nth-child(4)'),
       remove: By.css('#token-cell_dropdown_0 > div > div > li:nth-child(5)'),
-      sendText:'Send',
+      sendText: 'Send',
       viewText: 'View token on block explorer',
       copyText: 'Copy address to clipboard',
-      removeText: 'Remove'
+      removeText: 'Remove',
     },
     sandwich: {
       menu: By.css('.sandwich-expando'),
@@ -27,6 +27,7 @@ module.exports = {
     },
     account: {
       account1: By.css('#app-content > div > div.full-width > div > div:nth-child(2) > span > div > div > span > div > li:nth-child(2) > span'),
+      account2: By.css('#app-content > div > div.full-width > div > div:nth-child(2) > span > div > div > span > div > li:nth-child(3) > span'),
       menu: By.css('#app-content > div > div.full-width > div > div:nth-child(2) > span > div'),
       delete: By.css('#app-content > div > div.full-width > div > div:nth-child(2) > span > div > div > span > div > li:nth-child(4) > div.remove'),
       createAccount: By.css('#app-content > div > div.full-width > div > div:nth-child(2) > span > div > div > span > div > li:nth-child(3) > span'),
@@ -45,16 +46,26 @@ module.exports = {
     },
   },
   screens: {
-    sendTokens:{
-      title:By.className('flex-center'),
-      field:{
-        address:By.name('address'),
-        amount:By.name('amount')
+    sendTokens: {
+      error: By.className('error flex-center'),
+      errorText: {
+        invalidAmount: 'Invalid tokens\' amount',
+        address: 'Recipient address is invalid',
+        largeAmount: 'Insufficient tokens\' balance',
       },
-      button:{
-        next:By.css('#app-content > div > div.app-primary.from-right > div > section:nth-child(4) > button'),
-        arrow:By.className('fa fa-arrow-left fa-lg cursor-pointer')
-      }
+      title: By.className('flex-center'),
+      balance: By.className('hide-text-overflow token-balance__amount'),
+      symbol: By.className('token-balance__symbol'),
+      field: {
+        address: By.name('address'),
+        addressPlaceholder: 'Recipient Address',
+        amount: By.name('amount'),
+        amountPlaceholder: 'Amount',
+      },
+      button: {
+        next: By.xpath('//*[@id="app-content"]/div/div[4]/div/section[2]/button'),
+        arrow: By.className('fa fa-arrow-left fa-lg cursor-pointer'),
+      },
     },
     yourPR: {
       key: By.css('#app-content > div > div.app-primary.from-right > div > div.privateKey > div.flex-row > p'),
@@ -133,14 +144,17 @@ module.exports = {
       titleText: 'Delete Custom RPC',
     },
     confirmTransaction: {
-      buttons: {
+      title: By.className('flex-row flex-center'),
+      amount: By.css('#pending-tx-form > div:nth-child(1) > div.table-box > div:nth-child(2) > div.ether-balance.ether-balance-amount > div > div > div > div:nth-child(1)'),
+      symbol: By.css('#pending-tx-form > div:nth-child(1) > div.table-box > div:nth-child(2) > div.ether-balance.ether-balance-amount > div > div > div > div:nth-child(2)'),
+      button: {
         submit: By.css('#pending-tx-form > div.flex-row.flex-space-around.conf-buttons > input'),
       },
     },
     sendTransaction: {
       title: By.css('#app-content > div > div.app-primary.from-right > div > h3:nth-child(2)'),
       titleText: 'Send Transaction',
-      fields: {
+      field: {
         address: By.css('#app-content > div > div.app-primary.from-right > div > section:nth-child(3) > div > input'),
         amount: By.css('#app-content > div > div.app-primary.from-right > div > section:nth-child(4) > input'),
       },
@@ -192,7 +206,8 @@ module.exports = {
     },
     main: {
       identicon: By.className('identicon-wrapper select-none'),
-      accountName: By.className('sizing-input'),
+      fieldAccountName: By.className('sizing-input'),
+      accountName: By.css('#app-content > div > div.app-primary.from-left > div > div > div:nth-child(1) > flex-column > div.name-label > div > div > h2'),
       edit: By.className('edit-text'),
       iconCopy: By.className('clipboard cursor-pointer white'),
       transactionList: By.css('#app-content > div > div.app-primary.from-left > div > section > section > div > div > div > div.ether-balance.ether-balance-amount > div > div > div > div:nth-child(1)'),
@@ -212,7 +227,7 @@ module.exports = {
       tokens: {
         menu: By.className('inactiveForm pointer'),
         token: By.className('token-cell'),
-        balance: By.css('#app-content > div > div.app-primary.from-left > div > section > div.full-flex-height > ol > li:nth-child(2) > h3'),
+        balance: By.css('#token-cell_0 > h3'),
         amount: By.css('#app-content > div > div.app-primary.from-left > div > section > div.full-flex-height > div > span'),
         textNoTokens: 'No tokens found',
         textYouOwn1token: 'You own 1 token',

--- a/test/e2e/elements.js
+++ b/test/e2e/elements.js
@@ -52,6 +52,7 @@ module.exports = {
         invalidAmount: 'Invalid token\'s amount',
         address: 'Recipient address is invalid',
         largeAmount: 'Insufficient token\'s balance',
+        tooPrecise:'Token\'s amount is too precise'
       },
       title: By.className('flex-center'),
       balance: By.className('hide-text-overflow token-balance__amount'),

--- a/test/e2e/elements.js
+++ b/test/e2e/elements.js
@@ -53,7 +53,7 @@ module.exports = {
         address: 'Recipient address is invalid',
         largeAmount: 'Insufficient token\'s balance',
         tooPrecise: 'Token\'s amount is too precise',
-        negativeAmount:'Can not send negative amounts of ETH'
+        negativeAmount: 'Can not send negative amounts of ETH',
       },
       title: By.className('flex-center'),
       balance: By.className('hide-text-overflow token-balance__amount'),

--- a/test/e2e/elements.js
+++ b/test/e2e/elements.js
@@ -45,6 +45,17 @@ module.exports = {
     },
   },
   screens: {
+    sendTokens:{
+      title:By.className('flex-center'),
+      field:{
+        address:By.name('address'),
+        amount:By.name('amount')
+      },
+      button:{
+        next:By.css('#app-content > div > div.app-primary.from-right > div > section:nth-child(4) > button'),
+        arrow:By.className('fa fa-arrow-left fa-lg cursor-pointer')
+      }
+    },
     yourPR: {
       key: By.css('#app-content > div > div.app-primary.from-right > div > div.privateKey > div.flex-row > p'),
       copy: By.className('clipboard cursor-pointer'),

--- a/test/e2e/elements.js
+++ b/test/e2e/elements.js
@@ -52,7 +52,7 @@ module.exports = {
         invalidAmount: 'Invalid token\'s amount',
         address: 'Recipient address is invalid',
         largeAmount: 'Insufficient token\'s balance',
-        tooPrecise:'Token\'s amount is too precise'
+        tooPrecise: 'Token\'s amount is too precise',
       },
       title: By.className('flex-center'),
       balance: By.className('hide-text-overflow token-balance__amount'),

--- a/test/e2e/elements.js
+++ b/test/e2e/elements.js
@@ -49,9 +49,9 @@ module.exports = {
     sendTokens: {
       error: By.className('error flex-center'),
       errorText: {
-        invalidAmount: 'Invalid tokens\' amount',
+        invalidAmount: 'Invalid token\'s amount',
         address: 'Recipient address is invalid',
-        largeAmount: 'Insufficient tokens\' balance',
+        largeAmount: 'Insufficient token\'s balance',
       },
       title: By.className('flex-center'),
       balance: By.className('hide-text-overflow token-balance__amount'),

--- a/test/e2e/elements.js
+++ b/test/e2e/elements.js
@@ -53,6 +53,7 @@ module.exports = {
         address: 'Recipient address is invalid',
         largeAmount: 'Insufficient token\'s balance',
         tooPrecise: 'Token\'s amount is too precise',
+        negativeAmount:'Can not send negative amounts of ETH'
       },
       title: By.className('flex-center'),
       balance: By.className('hide-text-overflow token-balance__amount'),

--- a/test/e2e/elements.js
+++ b/test/e2e/elements.js
@@ -8,12 +8,14 @@ module.exports = {
     token: {
       menu: By.id('token-cell_dropdown_0'),
       items: By.className('dropdown-menu-item'),
-      view: By.css('#token-cell_dropdown_0 > div > div > li:nth-child(2)'),
-      copy: By.css('#token-cell_dropdown_0 > div > div > li:nth-child(3)'),
-      remove: By.css('#token-cell_dropdown_0 > div > div > li:nth-child(4)'),
+      send:By.css('#token-cell_dropdown_0 > div > div > li:nth-child(2)'),
+      view: By.css('#token-cell_dropdown_0 > div > div > li:nth-child(3)'),
+      copy: By.css('#token-cell_dropdown_0 > div > div > li:nth-child(4)'),
+      remove: By.css('#token-cell_dropdown_0 > div > div > li:nth-child(5)'),
+      sendText:'Send',
       viewText: 'View token on block explorer',
       copyText: 'Copy address to clipboard',
-      removeText: 'Remove',
+      removeText: 'Remove'
     },
     sandwich: {
       menu: By.css('.sandwich-expando'),

--- a/test/e2e/metamask.spec.js
+++ b/test/e2e/metamask.spec.js
@@ -1132,7 +1132,9 @@ describe('Metamask popup page', async function () {
 
       const account2 = '0x2f318C334780961FB129D2a6c30D0763d9a5C970'
       const invalidAddress = '0xkqjefwblknnecwe'
-
+      const invalidAmount = 'eeeee'
+      const largeAmount = '123'
+      const preciseAmount = '0.123456789123456789123'
       it('switch to account 1 ', async function () {
         const accountMenu = await waitUntilShowUp(menus.account.menu)
         await accountMenu.click()
@@ -1186,14 +1188,14 @@ describe('Metamask popup page', async function () {
         const button = await waitUntilShowUp(screens.sendTokens.button.next)
         await click(button)
         await click(button)
-        await delay(2000000000)
+        await delay(2000)
         const error = await waitUntilShowUp(screens.sendTokens.error)
         assert.equal(await error.getText(), screens.sendTokens.errorText.address, ' error message is incorrect')
       })
 
       it('error message if large amount', async function () {
         const amount = await waitUntilShowUp(screens.sendTokens.field.amount)
-        await amount.sendKeys('123')
+        await amount.sendKeys(largeAmount)
         const address = await waitUntilShowUp(screens.sendTokens.field.address)
         await clearField(address)
         await address.sendKeys(account2)
@@ -1203,6 +1205,29 @@ describe('Metamask popup page', async function () {
         await delay(2000)
         const error = await waitUntilShowUp(screens.sendTokens.error)
         assert.equal(await error.getText(), screens.sendTokens.errorText.largeAmount, ' error message is incorrect')
+      })
+
+      it('error message if invalid amount', async function () {
+        const amount = await waitUntilShowUp(screens.sendTokens.field.amount)
+        await clearField(amount)
+        await amount.sendKeys(invalidAmount)
+        const button = await waitUntilShowUp(screens.sendTokens.button.next)
+        await click(button)
+        await click(button)
+        await delay(2000)
+        const error = await waitUntilShowUp(screens.sendTokens.error)
+        assert.equal(await error.getText(), screens.sendTokens.errorText.invalidAmount, ' error message is incorrect')
+      })
+      it('error message if amount too precise', async function () {
+        const amount = await waitUntilShowUp(screens.sendTokens.field.amount)
+        await clearField(amount)
+        await amount.sendKeys(preciseAmount)
+        const button = await waitUntilShowUp(screens.sendTokens.button.next)
+        await click(button)
+        await click(button)
+        await delay(2000)
+        const error = await waitUntilShowUp(screens.sendTokens.error)
+        assert.equal(await error.getText(), screens.sendTokens.errorText.invalidAmount, ' error message is incorrect')
       })
 
       it('\'Confirm transaction\' screen is opened if address and amount are correct', async function () {

--- a/test/e2e/metamask.spec.js
+++ b/test/e2e/metamask.spec.js
@@ -305,7 +305,7 @@ describe('Metamask popup page', async function () {
     })
   })
 
-  describe('Change password', async () => {
+  describe.skip('Change password', async () => {
     const newPassword = {
       correct: 'abcDEF123!@#',
       short: '123',
@@ -607,7 +607,7 @@ describe('Metamask popup page', async function () {
     })
   })
 
-  describe('Add Token:Search', function () {
+  describe.skip('Add Token:Search', function () {
     const request = {
       valid: 'cry',
       invalid: 'zzz',
@@ -618,7 +618,7 @@ describe('Metamask popup page', async function () {
       address: '0x9a642d6b3368ddc662CA244bAdf32cDA716005BC',
     }
 
-    describe('add Mainnet\'s tokens', function () {
+    describe.skip('add Mainnet\'s tokens', function () {
 
       it(' field \'Search\' is displayed', async function () {
         await setProvider(NETWORKS.MAINNET)
@@ -821,7 +821,7 @@ describe('Metamask popup page', async function () {
       })
 
     })
-    describe('Token should be displayed only for network, where it was added ', async function () {
+    describe.skip('Token should be displayed only for network, where it was added ', async function () {
 
       it('token should not  be displayed in POA network', async function () {
         await setProvider(NETWORKS.POA)
@@ -854,7 +854,7 @@ describe('Metamask popup page', async function () {
         assert.equal(await assertTokensNotDisplayed(), true, 'tokens are displayed')
       })
     })
-    describe('remove Mainnet\'s tokens', function () {
+    describe.skip('remove Mainnet\'s tokens', function () {
 
       it('remove tokens', async function () {
         await setProvider(NETWORKS.MAINNET)
@@ -888,7 +888,7 @@ describe('Metamask popup page', async function () {
     })
   })
 
-  describe('Add Token: Custom', function () {
+  describe ('Add Token: Custom', function () {
 
     describe('Token Factory', function () {
 
@@ -946,6 +946,9 @@ describe('Metamask popup page', async function () {
 
       it('navigates to the add token screen', async function () {
         await waitUntilShowUp(screens.main.identicon)
+        const tab = await waitUntilShowUp(screens.main.tokens.menu)
+        await tab.click()
+
         const addTokenButton = await waitUntilShowUp(screens.main.tokens.buttonAdd)
         assert.equal(await addTokenButton.getText(), screens.main.tokens.buttonAddText)
         await click(addTokenButton)
@@ -988,7 +991,7 @@ describe('Metamask popup page', async function () {
       })
     })
 
-    describe('Check support of token per network basis ', async function () {
+    describe.skip('Check support of token per network basis ', async function () {
 
       describe('Token should be displayed only for network, where it was added ', async function () {
 
@@ -1023,7 +1026,7 @@ describe('Metamask popup page', async function () {
         })
       })
 
-      describe('Add token with the same address to each network  ', async function () {
+      describe.skip('Add token with the same address to each network  ', async function () {
 
         const tokenName = 'DVT'
         const tokenDecimals = '13'
@@ -1119,12 +1122,28 @@ describe('Metamask popup page', async function () {
       })
 
       it('item \'Send \' is displayed', async function () {
-        const menu = await waitUntilShowUp(menus.token.menu)
-        await menu.click()
         const item = await waitUntilShowUp(menus.token.send)
         assert.notEqual(item, false, 'item isn\'t displayed')
         assert.equal(await item.getText(), menus.token.sendText, 'incorrect name')
       })
+    })
+
+    describe('Transfer token', function () {
+
+      it('open screen transfer token ', async function () {
+        const item = await waitUntilShowUp(menus.token.send)
+        await item.click()
+        const title = await waitUntilShowUp(screens.sendTokens.title)
+        assert.equal(await title.getText(), 'Send TST tokens', 'title is incorrect')
+      })
+
+      it('open screen transfer token ', async function () {
+        const item = await waitUntilShowUp(menus.token.send)
+        await item.click()
+        const title = await waitUntilShowUp(screens.sendTokens.title)
+        assert.equal(await title.getText(), 'Send TST tokens', 'title is incorrect')
+      })
+
     })
 
     describe('Remove token , provider is localhost', function () {

--- a/test/e2e/metamask.spec.js
+++ b/test/e2e/metamask.spec.js
@@ -1219,7 +1219,7 @@ describe('Metamask popup page', async function () {
         const error = await waitUntilShowUp(screens.sendTokens.error)
         assert.equal(await error.getText(), screens.sendTokens.errorText.invalidAmount, ' error message is incorrect')
       })
-      it('error message if amount is too precise', async function () {
+      it.skip('error message if amount is too precise', async function () {
         const amount = await waitUntilShowUp(screens.sendTokens.field.amount)
         await clearField(amount)
         await amount.sendKeys(preciseAmount)

--- a/test/e2e/metamask.spec.js
+++ b/test/e2e/metamask.spec.js
@@ -1135,6 +1135,7 @@ describe('Metamask popup page', async function () {
       const invalidAmount = 'eeeee'
       const largeAmount = '123'
       const preciseAmount = '0.123456789123456789123'
+      const negativeAmount = '-1'
       it('switch to account 1 ', async function () {
         const accountMenu = await waitUntilShowUp(menus.account.menu)
         await accountMenu.click()
@@ -1193,7 +1194,7 @@ describe('Metamask popup page', async function () {
         assert.equal(await error.getText(), screens.sendTokens.errorText.address, ' error message is incorrect')
       })
 
-      it('error message if large amount', async function () {
+      it('error message if amount is large', async function () {
         const amount = await waitUntilShowUp(screens.sendTokens.field.amount)
         await amount.sendKeys(largeAmount)
         const address = await waitUntilShowUp(screens.sendTokens.field.address)
@@ -1207,7 +1208,7 @@ describe('Metamask popup page', async function () {
         assert.equal(await error.getText(), screens.sendTokens.errorText.largeAmount, ' error message is incorrect')
       })
 
-      it('error message if invalid amount', async function () {
+      it('error message if amount is invalid', async function () {
         const amount = await waitUntilShowUp(screens.sendTokens.field.amount)
         await clearField(amount)
         await amount.sendKeys(invalidAmount)
@@ -1218,7 +1219,7 @@ describe('Metamask popup page', async function () {
         const error = await waitUntilShowUp(screens.sendTokens.error)
         assert.equal(await error.getText(), screens.sendTokens.errorText.invalidAmount, ' error message is incorrect')
       })
-      it('error message if amount too precise', async function () {
+      it('error message if amount is too precise', async function () {
         const amount = await waitUntilShowUp(screens.sendTokens.field.amount)
         await clearField(amount)
         await amount.sendKeys(preciseAmount)
@@ -1227,7 +1228,19 @@ describe('Metamask popup page', async function () {
         await click(button)
         await delay(2000)
         const error = await waitUntilShowUp(screens.sendTokens.error)
-        assert.equal(await error.getText(), screens.sendTokens.errorText.invalidAmount, ' error message is incorrect')
+        assert.equal(await error.getText(), screens.sendTokens.errorText.tooPrecise, ' error message is incorrect')
+      })
+
+      it('error message if amount is negative', async function () {
+        const amount = await waitUntilShowUp(screens.sendTokens.field.amount)
+        await clearField(amount)
+        await amount.sendKeys(negativeAmount)
+        const button = await waitUntilShowUp(screens.sendTokens.button.next)
+        await click(button)
+        await click(button)
+        await delay(2000)
+        const error = await waitUntilShowUp(screens.sendTokens.error)
+        assert.equal(await error.getText(), screens.sendTokens.errorText.negativeAmount, ' error message is incorrect')
       })
 
       it('\'Confirm transaction\' screen is opened if address and amount are correct', async function () {

--- a/test/e2e/metamask.spec.js
+++ b/test/e2e/metamask.spec.js
@@ -1186,7 +1186,7 @@ describe('Metamask popup page', async function () {
         const button = await waitUntilShowUp(screens.sendTokens.button.next)
         await click(button)
         await click(button)
-        await delay(2000)
+        await delay(2000000000)
         const error = await waitUntilShowUp(screens.sendTokens.error)
         assert.equal(await error.getText(), screens.sendTokens.errorText.address, ' error message is incorrect')
       })

--- a/test/e2e/metamask.spec.js
+++ b/test/e2e/metamask.spec.js
@@ -133,13 +133,13 @@ describe('Metamask popup page', async function () {
       await menu.click()
       const field = await waitUntilShowUp(screens.main.edit)
       await field.click()
-      const accountName = await waitUntilShowUp(screens.main.accountName)
+      const accountName = await waitUntilShowUp(screens.main.fieldAccountName)
       assert.notEqual(accountName, false, '\'Account name\' change dialog isn\'t opened')
       assert.equal(await accountName.getAttribute('value'), 'Account 1', 'incorrect placeholder')
     })
 
     it('fill out new account\'s name', async () => {
-      const field = await waitUntilShowUp(screens.main.accountName)
+      const field = await waitUntilShowUp(screens.main.fieldAccountName)
       await field.clear()
       await field.sendKeys(newAccountName)
     })
@@ -149,7 +149,7 @@ describe('Metamask popup page', async function () {
       assert.equal(await button.getText(), 'Save', 'button has incorrect name')
       assert.notEqual(button, true, 'button \'Save\' does not present')
       await click(button)
-      const accountName = await waitUntilShowUp(screens.main.accountName, 10)
+      const accountName = await waitUntilShowUp(screens.main.fieldAccountName, 10)
       assert.equal(accountName, false, '\'Account name\' change dialog isn\'t opened')
     })
 
@@ -305,7 +305,7 @@ describe('Metamask popup page', async function () {
     })
   })
 
-  describe.skip('Change password', async () => {
+  describe('Change password', async () => {
     const newPassword = {
       correct: 'abcDEF123!@#',
       short: '123',
@@ -586,8 +586,8 @@ describe('Metamask popup page', async function () {
     it('adds recipient address and amount', async function () {
       const sendTranscationScreen = await waitUntilShowUp(screens.sendTransaction.title)
       assert.equal(await sendTranscationScreen.getText(), screens.sendTransaction.titleText, 'Transaction screen has incorrect titlr')
-      const inputAddress = await waitUntilShowUp(screens.sendTransaction.fields.address)
-      const inputAmmount = await waitUntilShowUp(screens.sendTransaction.fields.amount)
+      const inputAddress = await waitUntilShowUp(screens.sendTransaction.field.address)
+      const inputAmmount = await waitUntilShowUp(screens.sendTransaction.field.amount)
       await inputAddress.sendKeys('0x2f318C334780961FB129D2a6c30D0763d9a5C970')
       await inputAmmount.sendKeys('10')
       const button = await waitUntilShowUp(screens.sendTransaction.buttonNext)
@@ -596,7 +596,7 @@ describe('Metamask popup page', async function () {
     })
 
     it('confirms transaction', async function () {
-      const button = await waitUntilShowUp(screens.confirmTransaction.buttons.submit)
+      const button = await waitUntilShowUp(screens.confirmTransaction.button.submit)
       assert.equal(await button.getAttribute('value'), 'Submit', 'button has incorrect name')
       await click(button)
     })
@@ -607,7 +607,7 @@ describe('Metamask popup page', async function () {
     })
   })
 
-  describe.skip('Add Token:Search', function () {
+  describe('Add Token:Search', function () {
     const request = {
       valid: 'cry',
       invalid: 'zzz',
@@ -618,7 +618,7 @@ describe('Metamask popup page', async function () {
       address: '0x9a642d6b3368ddc662CA244bAdf32cDA716005BC',
     }
 
-    describe.skip('add Mainnet\'s tokens', function () {
+    describe('add Mainnet\'s tokens', function () {
 
       it(' field \'Search\' is displayed', async function () {
         await setProvider(NETWORKS.MAINNET)
@@ -821,7 +821,7 @@ describe('Metamask popup page', async function () {
       })
 
     })
-    describe.skip('Token should be displayed only for network, where it was added ', async function () {
+    describe('Token should be displayed only for network, where it was added ', async function () {
 
       it('token should not  be displayed in POA network', async function () {
         await setProvider(NETWORKS.POA)
@@ -854,7 +854,7 @@ describe('Metamask popup page', async function () {
         assert.equal(await assertTokensNotDisplayed(), true, 'tokens are displayed')
       })
     })
-    describe.skip('remove Mainnet\'s tokens', function () {
+    describe('remove Mainnet\'s tokens', function () {
 
       it('remove tokens', async function () {
         await setProvider(NETWORKS.MAINNET)
@@ -888,7 +888,7 @@ describe('Metamask popup page', async function () {
     })
   })
 
-  describe ('Add Token: Custom', function () {
+  describe('Add Token: Custom', function () {
 
     describe('Token Factory', function () {
 
@@ -921,7 +921,7 @@ describe('Metamask popup page', async function () {
       it('confirms transaction in MetaMask popup', async function () {
         const windowHandles = await driver.getAllWindowHandles()
         await driver.switchTo().window(windowHandles[windowHandles.length - 1])
-        const button = await waitUntilShowUp(screens.confirmTransaction.buttons.submit)
+        const button = await waitUntilShowUp(screens.confirmTransaction.button.submit)
         await click(button)
       })
 
@@ -960,7 +960,7 @@ describe('Metamask popup page', async function () {
       })
 
       it('adds token parameters', async function () {
-        const tab = await waitUntilShowUp(screens.addToken.tab.custom)
+        const tab = await waitUntilShowUp(screens.addToken.tab.custom, 30)
         if (!await waitUntilShowUp(screens.addToken.custom.fields.contractAddress)) await tab.click()
         const tokenContractAddress = await waitUntilShowUp(screens.addToken.custom.fields.contractAddress)
         await tokenContractAddress.sendKeys(tokenAddress)
@@ -990,8 +990,52 @@ describe('Metamask popup page', async function () {
         await switchToFirstPage()
       })
     })
+    describe('Token menu', function () {
 
-    describe.skip('Check support of token per network basis ', async function () {
+      it('token menu is displayed and clickable ', async function () {
+        const menu = await waitUntilShowUp(menus.token.menu)
+        await menu.click()
+      })
+
+      it('link \'View on blockexplorer...\' leads to correct page ', async function () {
+        const menu = await waitUntilShowUp(menus.token.view)
+        assert.notEqual(menu, false, 'item isn\'t displayed')
+        assert.equal(await menu.getText(), menus.token.viewText, 'incorrect name')
+        await menu.click()
+        await switchToLastPage()
+        const title = await driver.getCurrentUrl()
+        assert.equal(title.includes('https://etherscan.io/token/'), true, 'link leads to wrong page')
+        await switchToFirstPage()
+      })
+
+      it('item \'Copy\' is displayed and clickable ', async function () {
+        let menu = await waitUntilShowUp(menus.token.menu)
+        await menu.click()
+        const item = await waitUntilShowUp(menus.token.copy)
+        assert.notEqual(item, false, 'item isn\'t displayed')
+        assert.equal(await item.getText(), menus.token.copyText, 'incorrect name')
+        await item.click()
+        menu = await waitUntilShowUp(menus.token.menu, 10)
+        assert.notEqual(menu, false, 'menu wasn\'t closed')
+      })
+
+      it('item \'Remove\' is displayed', async function () {
+        const menu = await waitUntilShowUp(menus.token.menu)
+        await menu.click()
+        const item = await waitUntilShowUp(menus.token.remove)
+        assert.notEqual(item, false, 'item isn\'t displayed')
+        assert.equal(await item.getText(), menus.token.removeText, 'incorrect name')
+      })
+
+      it('item \'Send \' is displayed', async function () {
+        const item = await waitUntilShowUp(menus.token.send)
+        assert.notEqual(item, false, 'item isn\'t displayed')
+        assert.equal(await item.getText(), menus.token.sendText, 'incorrect name')
+        await waitUntilShowUp(menus.token.menu)
+      })
+    })
+
+    describe('Check support of token per network basis ', async function () {
 
       describe('Token should be displayed only for network, where it was added ', async function () {
 
@@ -1026,7 +1070,7 @@ describe('Metamask popup page', async function () {
         })
       })
 
-      describe.skip('Add token with the same address to each network  ', async function () {
+      describe('Add token with the same address to each network  ', async function () {
 
         const tokenName = 'DVT'
         const tokenDecimals = '13'
@@ -1084,68 +1128,140 @@ describe('Metamask popup page', async function () {
       })
     })
 
-    describe('Token menu', function () {
+    describe('Transfer tokens', function () {
 
-      it('token menu is displayed and clickable ', async function () {
+      const account2 = '0x2f318C334780961FB129D2a6c30D0763d9a5C970'
+      const invalidAddress = '0xkqjefwblknnecwe'
+
+      it('switch to account 1 ', async function () {
+        const accountMenu = await waitUntilShowUp(menus.account.menu)
+        await accountMenu.click()
+        const item = await waitUntilShowUp(menus.account.account1)
+        await item.click()
+        await delay(2000)
+        const accountName = await waitUntilShowUp(screens.main.accountName)
+        assert.equal(await accountName.getText(), 'Account 1', 'account name incorrect')
+      })
+
+      it('open screen \'Transfer tokens\' ', async function () {
         const menu = await waitUntilShowUp(menus.token.menu)
         await menu.click()
-      })
-
-      it('link \'View on blockexplorer...\' leads to correct page ', async function () {
-        const menu = await waitUntilShowUp(menus.token.view)
-        assert.notEqual(menu, false, 'item isn\'t displayed')
-        assert.equal(await menu.getText(), menus.token.viewText, 'incorrect name')
-        await menu.click()
-        await switchToLastPage()
-        const title = await driver.getCurrentUrl()
-        assert.equal(title.includes('https://etherscan.io/token/'), true, 'link leads to wrong page')
-        await switchToFirstPage()
-      })
-
-      it('item \'Copy\' is displayed and clickable ', async function () {
-        let menu = await waitUntilShowUp(menus.token.menu)
-        await menu.click()
-        const item = await waitUntilShowUp(menus.token.copy)
-        assert.notEqual(item, false, 'item isn\'t displayed')
-        assert.equal(await item.getText(), menus.token.copyText, 'incorrect name')
-        await item.click()
-        menu = await waitUntilShowUp(menus.token.menu, 10)
-        assert.notEqual(menu, false, 'menu wasn\'t closed')
-      })
-
-      it('item \'Remove\' is displayed', async function () {
-        const menu = await waitUntilShowUp(menus.token.menu)
-        await menu.click()
-        const item = await waitUntilShowUp(menus.token.remove)
-        assert.notEqual(item, false, 'item isn\'t displayed')
-        assert.equal(await item.getText(), menus.token.removeText, 'incorrect name')
-      })
-
-      it('item \'Send \' is displayed', async function () {
         const item = await waitUntilShowUp(menus.token.send)
-        assert.notEqual(item, false, 'item isn\'t displayed')
-        assert.equal(await item.getText(), menus.token.sendText, 'incorrect name')
+        await item.click()
+      })
+
+      it('field \'Amount\' is displayed and has correct placeholder ', async function () {
+        const item = await waitUntilShowUp(screens.sendTokens.field.amount)
+        assert.equal(await item.getAttribute('placeholder'), screens.sendTokens.field.amountPlaceholder, 'placeholder is incorrect')
+      })
+
+      it('field \'Address\' is displayed and has correct placeholder ', async function () {
+        const item = await waitUntilShowUp(screens.sendTokens.field.address)
+        assert.equal(await item.getAttribute('placeholder'), screens.sendTokens.field.addressPlaceholder, 'placeholder is incorrect')
+      })
+
+      it('token\'s balance is correct ', async function () {
+        const item = await waitUntilShowUp(screens.sendTokens.balance)
+        assert.equal(await item.getText(), '100', 'token\'s balance is incorrect')
+      })
+
+      it('token\'s symbol is correct ', async function () {
+        const item = await waitUntilShowUp(screens.sendTokens.symbol)
+        assert.equal(await item.getText(), 'TST', 'token\'s symbol is incorrect')
+      })
+
+      it('error message if invalid token\'s amount', async function () {
+        const button = await waitUntilShowUp(screens.sendTokens.button.next)
+        assert.equal(await button.getText(), 'Next', 'button \'Next\' has incorrect name')
+        await click(button)
+        const error = await waitUntilShowUp(screens.sendTokens.error)
+        assert.equal(await error.getText(), screens.sendTokens.errorText.invalidAmount, ' error message is incorrect')
+      })
+
+      it('error message if invalid address', async function () {
+        const amount = await waitUntilShowUp(screens.sendTokens.field.amount)
+        await amount.sendKeys('1')
+        const address = await waitUntilShowUp(screens.sendTokens.field.address)
+        await address.sendKeys(invalidAddress)
+        const button = await waitUntilShowUp(screens.sendTokens.button.next)
+        await click(button)
+        await click(button)
+        await delay(2000)
+        const error = await waitUntilShowUp(screens.sendTokens.error)
+        assert.equal(await error.getText(), screens.sendTokens.errorText.address, ' error message is incorrect')
+      })
+
+      it('error message if large amount', async function () {
+        const amount = await waitUntilShowUp(screens.sendTokens.field.amount)
+        await amount.sendKeys('123')
+        const address = await waitUntilShowUp(screens.sendTokens.field.address)
+        await clearField(address)
+        await address.sendKeys(account2)
+        const button = await waitUntilShowUp(screens.sendTokens.button.next)
+        await click(button)
+        await click(button)
+        await delay(2000)
+        const error = await waitUntilShowUp(screens.sendTokens.error)
+        assert.equal(await error.getText(), screens.sendTokens.errorText.largeAmount, ' error message is incorrect')
+      })
+
+      it('\'Confirm transaction\' screen is opened if address and amount are correct', async function () {
+        const amount = await waitUntilShowUp(screens.sendTokens.field.amount)
+        await clearField(amount)
+        await amount.sendKeys('5')
+        const button = await waitUntilShowUp(screens.sendTokens.button.next)
+        await click(button)
+
+        const buttonSubmit = await waitUntilShowUp(screens.confirmTransaction.button.submit)
+        assert.notEqual(buttonSubmit, false, 'incorrect screen was opened')
+      })
+
+      it('\'Confirm transaction\' screen: token\'s amount is correct', async function () {
+        const amount = await waitUntilShowUp(screens.confirmTransaction.amount)
+        assert.equal(await amount.getText(), '5.000', ' amount is incorrect')
+      })
+
+      it('\'Confirm transaction\' screen: token\'s symbol is correct', async function () {
+        const symbol = await waitUntilShowUp(screens.confirmTransaction.symbol)
+        assert.equal(await symbol.getText(), 'TST', ' symbol is incorrect')
+      })
+
+      it('submit transaction', async function () {
+        await driver.navigate().refresh()
+        const button = await waitUntilShowUp(screens.confirmTransaction.button.submit)
+        await click(button)
+        const list = await waitUntilShowUp(screens.main.transactionList)
+        assert.notEqual(list, false, ' main screen isn\'t opened')
+      })
+
+      it('correct amount substracted from sender\'s tokens balance', async function () {
+        const tab = await waitUntilShowUp(screens.main.tokens.menu)
+        await tab.click()
+        await driver.navigate().refresh()
+        await delay(5000)
+        await driver.navigate().refresh()
+        await delay(5000)
+        await driver.navigate().refresh()
+        await delay(5000)
+        const balance = await waitUntilShowUp(screens.main.tokens.balance)
+
+        assert.equal(await balance.getText(), '95 TST', 'balance is incorrect')
+      })
+      it('switch to account 2 ', async function () {
+        const accountMenu = await waitUntilShowUp(menus.account.menu)
+        await accountMenu.click()
+        const item = await waitUntilShowUp(menus.account.account2)
+        await item.click()
+        await delay(2000)
+        const accountName = await waitUntilShowUp(screens.main.accountName)
+        assert.equal(await accountName.getText(), 'Account 2', 'account name incorrect')
+      })
+
+      it('receiver got correct amount of tokens', async function () {
+        const balance = await waitUntilShowUp(screens.main.tokens.balance)
+        assert.equal(await balance.getText(), '5 TST', 'balance is incorrect')
       })
     })
-
-    describe('Transfer token', function () {
-
-      it('open screen transfer token ', async function () {
-        const item = await waitUntilShowUp(menus.token.send)
-        await item.click()
-        const title = await waitUntilShowUp(screens.sendTokens.title)
-        assert.equal(await title.getText(), 'Send TST tokens', 'title is incorrect')
-      })
-
-      it('open screen transfer token ', async function () {
-        const item = await waitUntilShowUp(menus.token.send)
-        await item.click()
-        const title = await waitUntilShowUp(screens.sendTokens.title)
-        assert.equal(await title.getText(), 'Send TST tokens', 'title is incorrect')
-      })
-
-    })
-
     describe('Remove token , provider is localhost', function () {
 
       it('remove option opens \'Remove token\' screen ', async function () {

--- a/test/e2e/metamask.spec.js
+++ b/test/e2e/metamask.spec.js
@@ -1117,6 +1117,14 @@ describe('Metamask popup page', async function () {
         assert.notEqual(item, false, 'item isn\'t displayed')
         assert.equal(await item.getText(), menus.token.removeText, 'incorrect name')
       })
+
+      it('item \'Send \' is displayed', async function () {
+        const menu = await waitUntilShowUp(menus.token.menu)
+        await menu.click()
+        const item = await waitUntilShowUp(menus.token.send)
+        assert.notEqual(item, false, 'item isn\'t displayed')
+        assert.equal(await item.getText(), menus.token.sendText, 'incorrect name')
+      })
     })
 
     describe('Remove token , provider is localhost', function () {


### PR DESCRIPTION
Relates https://github.com/poanetwork/metamask-extension/issues/134
Added e2e tests for feature ‘send token’ https://github.com/poanetwork/metamask-extension/pull/145
```
 Transfer tokens
        ✓ switch to account 1  (2590ms)
        ✓ open screen 'Transfer tokens'  (423ms)
        ✓ field 'Amount' is displayed and has correct placeholder  (143ms)
        ✓ field 'Address' is displayed and has correct placeholder  (144ms)
        ✓ token's balance is correct  (157ms)
        ✓ token's symbol is correct  (155ms)
        ✓ error message if invalid token's amount (365ms)
        ✓ error message if invalid address (2758ms)
        ✓ error message if amount is large (3623ms)
        ✓ error message if amount is invalid (3173ms)
        ✓ error message if amount is too precise (3252ms)
        ✓ error message if amount is negative (3220ms)
        ✓ 'Confirm transaction' screen is opened if address and amount are correct (1465ms)
        ✓ 'Confirm transaction' screen: token's amount is correct (159ms)
        ✓ 'Confirm transaction' screen: token's symbol is correct (155ms)
        ✓ submit transaction (1722ms)
        ✓ correct amount substracted from sender's tokens balance (17088ms)
        ✓ switch to account 2  (2595ms)
        ✓ receiver got correct amount of tokens (155ms)
```
Also minor fixes in `send-token.js` :
1. Validation of error if amount too precise
2. Typos in error messages
