### PR TITLE
(Fix) memory leaks: unreleased interval and events

### DIFF
--- a/app/scripts/controllers/blacklist.js
+++ b/app/scripts/controllers/blacklist.js
@@ -96,7 +96,9 @@ class BlacklistController {
    *
    */
   scheduleUpdates () {
-    if (this._phishingUpdateIntervalRef) return
+    if (this._phishingUpdateIntervalRef) {
+      clearInterval(this._phishingUpdateIntervalRef)
+    }
     this.updatePhishingList().catch(log.warn)
     this._phishingUpdateIntervalRef = setInterval(() => {
       this.updatePhishingList().catch(log.warn)

--- a/old-ui/app/components/menu-droppo.js
+++ b/old-ui/app/components/menu-droppo.js
@@ -80,24 +80,24 @@ MenuDroppoComponent.prototype.componentDidMount = function () {
     this.container = container
   }
 
+  this.transitionStarted = this.transitionstartOccured.bind(this)
+
   /*
    * transitionstart event is not supported in Chrome yet. But it works for Firefox 53+.
    * We need to handle this event only for FF because for Chrome we've hidden scrolls.
   */
-  this.refs.menuDroppoContainer.addEventListener('transitionstart', () => {
-    this.refs.menuDroppoContainer.style.overflow = 'hidden'
-  })
+  this.refs.menuDroppoContainer.addEventListener('transitionstart', this.transitionStarted)
 
-  this.refs.menuDroppoContainer.addEventListener('transitionend', () => {
-    if (!this.props.constOverflow) {
-      this.refs.menuDroppoContainer.style.overflow = 'auto'
-    }
-  })
+  this.transitionEnded = this.transitionendOccured.bind(this)
+
+  this.refs.menuDroppoContainer.addEventListener('transitionend', this.transitionEnded)
 }
 
 MenuDroppoComponent.prototype.componentWillUnmount = function () {
   if (this && document.body) {
     document.body.removeEventListener('click', this.globalClickHandler)
+    document.body.removeEventListener('transitionstart', this.transitionStarted)
+    document.body.removeEventListener('transitionend', this.transitionEnded)
   }
 }
 
@@ -110,6 +110,16 @@ MenuDroppoComponent.prototype.globalClickOccurred = function (event) {
     !isDescendant(this.container, event.target) &&
     this.outsideClickHandler) {
     this.outsideClickHandler(event)
+  }
+}
+
+MenuDroppoComponent.prototype.transitionstartOccured = function (event) {
+  this.refs.menuDroppoContainer.style.overflow = 'hidden'
+}
+
+MenuDroppoComponent.prototype.transitionendOccured = function (event) {
+  if (!this.props.constOverflow) {
+    this.refs.menuDroppoContainer.style.overflow = 'auto'
   }
 }
 


### PR DESCRIPTION
Relates to https://github.com/poanetwork/metamask-extension/issues/157

In addition to this memory leak fix https://github.com/poanetwork/metamask-extension/commit/ee568d5f5a3d04f32969fd2ba3113b9eeb175d63, that has been merged previously in this PR https://github.com/poanetwork/metamask-extension/pull/169 into dev branch of NW, unreleased interval and `transitionstart`, `transitionend` events could cause memory leaks in NW, also.
This PR fixes it with implementing of removal of events on unmounting of a component and clearing of `_phishingUpdateIntervalRef` interval.