### PR TITLE
(Fix) multiple explorers are opened on success tx notification click

### DIFF
--- a/app/scripts/platforms/extension.js
+++ b/app/scripts/platforms/extension.js
@@ -110,14 +110,14 @@ class ExtensionPlatform {
   }
 
   _subscribeToNotificationClicked = () => {
-    if (!extension.notifications.onClicked.hasListener(this._viewOnExplorer)) {
-      extension.notifications.onClicked.addListener((url) => this._viewOnExplorer(url))
+    if (extension.notifications.onClicked.hasListener(this._viewOnExplorer)) {
+      extension.notifications.onClicked.removeListener(this._viewOnExplorer)
     }
+    extension.notifications.onClicked.addListener(this._viewOnExplorer)
   }
 
   _viewOnExplorer (url) {
     if (url.startsWith('http://') || url.startsWith('https://')) {
-      extension.notifications.onClicked.removeListener(this._viewOnExplorer)
       global.metamaskController.platform.openWindow({ url })
     }
   }


### PR DESCRIPTION
Multiple block explorers tabs are opened on a single click on success tx notification.
@dennis00010011b please add e2e tests, that only one explorer tab is opened per one click to the notification.